### PR TITLE
CSPACE-5270: Add back <repositories> block that points to lib-snapshot-local in artifactory

### DIFF
--- a/cspi-services/pom.xml
+++ b/cspi-services/pom.xml
@@ -14,6 +14,13 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
   
+  <repositories>
+    <repository>
+        <id>libs-snapshots-local</id>
+        <name>libs-snapshots-local</name>
+        <url>http://source.collectionspace.org:8081/artifactory/libs-snapshots-local</url>
+    </repository>
+  </repositories>
 
   <dependencies>
 


### PR DESCRIPTION
This is the block that was left out of my earlier commit. With it in  place, org.collectionspace.services.common-api gets deposited in the local .m2 repo and the app layer builds successfully.

Please add to master. Thanks!
