### PR TITLE
CSPACE-5406: Remove code that was special-casing URI values...

### DIFF
--- a/cspi-services/src/main/java/org/collectionspace/chain/csp/persistence/services/GenericStorage.java
+++ b/cspi-services/src/main/java/org/collectionspace/chain/csp/persistence/services/GenericStorage.java
@@ -885,16 +885,6 @@ public class GenericStorage  implements ContextualisedStorage {
 					resetGlean(thisr,reset_good,reset_map,reset_deurn,reset_merge, true);// what glean info required for this one..
 					String csid = parts[parts.length-1];
 					JSONObject dataitem = null;
-                                        // CSPACE-5406 - ADR 2012-07-19
-                                        /*
-					if(thisr.isType("authority")){
-						dataitem =  miniViewRetrieveJSON(cache,creds,csid, "terms", thisr.getServicesURL()+"/"+uri, thisr);
-					}
-					else{
-						dataitem =  miniViewRetrieveJSON(cache,creds,csid, "terms", uri, thisr);
-					}
-                                        * 
-                                        */
                                         dataitem =  miniViewRetrieveJSON(cache,creds,csid, "terms", uri, thisr);
 					//JSONObject 
 					dataitem.getJSONObject("summarylist").put("uri",filePath);


### PR DESCRIPTION
... for authority items by prepending additional values, in refObjs lists
built by the App layer.  This was causin Used By lists in the
right sidebar, on authority term record pages, to fail to display
any items, if even just one other authority term record
referenced the current term in one of its fields.
