### PR TITLE
CSPACE-5333: Removed 'mini' attributes from termType field in four termL...

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-authority-concept-termList.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-concept-termList.xml
@@ -13,7 +13,7 @@
             <field id="termName">
                 <selector>conceptAuthority-termName</selector>
             </field>
-            <field id="termType" mini="summary,search,list,relate">
+            <field id="termType">
                 <selector>conceptAuthority-termType</selector>
                 <options>
                     <option id="">Please select a value</option>

--- a/tomcat-main/src/main/resources/defaults/base-authority-location-termList.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-location-termList.xml
@@ -10,10 +10,10 @@
                 <title-selector>titleBar-termDisplayName</title-selector>
             </field>
             <!-- FIXME: Add 'ui-search="repeatable"' back to this field when CSPACE-5184/CSPACE-5185 is fixed -->
-            <field id="termName" mini="summary,list,search,relate,terms">
+            <field id="termName">
                 <selector>locationAuthority-termName</selector>
             </field>
-            <field id="termType" mini="summary,search,list,relate">
+            <field id="termType">
                 <selector>locationAuthority-termType</selector>
                 <options>
                     <option id="">Please select a value</option>

--- a/tomcat-main/src/main/resources/defaults/base-authority-organization-termList.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-organization-termList.xml
@@ -12,7 +12,7 @@
             <field id="termName">
                 <selector>orgAuthority-termName</selector>
             </field>
-            <field id="termType" mini="summary,search,list,relate">
+            <field id="termType">
                 <selector>orgAuthority-termType</selector>
                 <options>
                     <option id="">Please select a value</option>

--- a/tomcat-main/src/main/resources/defaults/base-authority-taxon-termList.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-taxon-termList.xml
@@ -15,7 +15,7 @@
             <!-- Recommendation: Hide termType in the UI because taxonomy has established -->
             <!-- international nomenclature standards. -->
             <!-- FIXME: Should we remove this field from mini-records? - ADR 2012-05-18 -->
-            <field id="termType" mini="summary,search,list,relate">
+            <field id="termType">
                 <selector>taxonAuthority-termType</selector>
                 <options>
                     <option id="">Please select a value</option>


### PR DESCRIPTION
...ist config files, and from termName field in one such config file, in an effort to prevent fanout when returning lists of authority items for Organization, Storage Location, Concept, and Taxon.
