### PR TITLE
CSPACE-5718: Adding <hierarchy-section> to base-collectionobject.xml to ...

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -33,6 +33,13 @@
     </structure>
     <structure id="tab">
       <view>
+        <hierarchy-section show="true">
+          <options>
+            <!-- The values here may not be used, but are here for completeness -->
+            <option id="narrowerContext">collection-object</option>
+            <option id="broaderContext">collection-object</option>
+          </options>
+        </hierarchy-section>
         <titlebar show="false"/>
         <sidebar show="false"/>
         <edit-section id="details" show="true"/>


### PR DESCRIPTION
...fix hierarchy on cataloging-tab

Tests pass, uispec contains {hierarchy...} section after implementing this change.

NOTE: I'm seeing errors in retrieving both Broader objects and Object components that have been created using object hierarchy. The errors appear both on nightly and on my local stack (before and after deploying this patch), so I don't believe they have anything to do with this configuration change. If you'd like, I'd be happy to review the errors with you prior to you merging this pull request.
- Rick
