### PR TITLE
CSPACE-6163: Re-enable Hard Save option for Movement records. Update cod...

### DIFF
--- a/cspi-installation/src/main/java/org/collectionspace/chain/installation/XsdGeneration.java
+++ b/cspi-installation/src/main/java/org/collectionspace/chain/installation/XsdGeneration.java
@@ -77,7 +77,8 @@ public class XsdGeneration {
 	private static final String SERVICE_NAME_LOWERCASE_VAR = "${ServiceName_LowerCase}";	
 	
 	private static final String DOCTYPE_DEFAULT_LIFECYCLE = "cs_default";
-	private static final String DOCTYPE_LIFECYCLE_VAR = "${Lifecycle}";
+        private static final String DOCTYPE_LOCKING_LIFECYCLE = "cs_locking";
+        private static final String DOCTYPE_LIFECYCLE_VAR = "${Lifecycle}";
 	
 	private static final String BUNDLE_SYM_NAME = "${BundleSymbolicName}";
 	private static final String AUTH_BUNDLE_SYM_NAME = "${AuthBundleSymbolicName}";
@@ -328,7 +329,8 @@ public class XsdGeneration {
 			HashMap<String, String> definedSchemaList,
 			File outputDir) throws Exception {
 		boolean isAuthorityItemType = record.isAuthorityItemType();
-		String serviceName = record.getServicesTenantSg();
+                boolean supportsLocking = record.supportsLocking();
+                String serviceName = record.getServicesTenantSg();
 		String tenantName = record.getSpec().getAdminData().getTenantName();
 		String docTypeName = record.getServicesTenantDoctype(false); // 'false' means we're not treating the record as an authority
 		//
@@ -361,8 +363,12 @@ public class XsdGeneration {
 				HashMap<String, String> substitutionMap = new HashMap<String, String>();
 				substitutionMap.put(SERVICE_NAME_VAR, serviceName);
 				substitutionMap.put(SERVICE_NAME_LOWERCASE_VAR, serviceName.toLowerCase());
-				substitutionMap.put(DOCTYPE_LIFECYCLE_VAR, DOCTYPE_DEFAULT_LIFECYCLE);
-				substitutionMap.put(DOCTYPE_NAME_VAR, docTypeName);
+                                if (supportsLocking) {
+                                    substitutionMap.put(DOCTYPE_LIFECYCLE_VAR, DOCTYPE_LOCKING_LIFECYCLE);
+                                } else {
+                                    substitutionMap.put(DOCTYPE_LIFECYCLE_VAR, DOCTYPE_DEFAULT_LIFECYCLE);
+                                }
+                                substitutionMap.put(DOCTYPE_NAME_VAR, docTypeName);
 				substitutionMap.put(DOCTYPE_NAME_LOWERCASE_VAR, docTypeName.toLowerCase());
 				if (isAuthorityItemType == true) {
 					String authoritySchemaName = FilenameUtils.removeExtension(getAuthoritiesCommonName(record));

--- a/tomcat-main/src/main/resources/defaults/base-procedure-movement.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-movement.xml
@@ -48,8 +48,8 @@
 				
                 <section id="coreInformation">
                     <include src="core-fields.xml"  strip-root="yes" />
-					<field id="workflow" exists-in-services="false" section="collectionspace_core" attributes="GET" 
-									mini="search,list">
+					<field id="workflow" exists-in-services="false" services-derived="true"
+                                               section="collectionspace_core" attributes="GET" mini="search,list">
 						<services-tag>workflowState</services-tag>
 					</field>
                 </section>


### PR DESCRIPTION
...e which generates Nuxeo document type bundles to set the 'cs_locking' lifecycle for record types configured with supportslocking flag. Emit current workflow state among with other collectionspace_core values for Movement records.
