### PR TITLE
CSPACE-6176: Allow App layer configuration to specify the repositoryName...

### DIFF
--- a/cspi-installation/pom.xml
+++ b/cspi-installation/pom.xml
@@ -96,6 +96,11 @@
 			<version>4.0-SNAPSHOT</version>
 			<type>jar</type>
 		</dependency>
+                <dependency>
+			<groupId>org.collectionspace.services</groupId>
+			<artifactId>org.collectionspace.services.common-api</artifactId>
+                        <version>4.0-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/cspi-installation/src/main/java/org/collectionspace/chain/installation/Services.java
+++ b/cspi-installation/src/main/java/org/collectionspace/chain/installation/Services.java
@@ -22,6 +22,7 @@ import org.dom4j.QName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.commons.io.FileUtils;
+import org.collectionspace.services.common.api.Tools;
 
 public class Services {
 	private static final Logger log = LoggerFactory.getLogger(Services.class);
@@ -157,7 +158,10 @@ public class Services {
 		Element rele = ele.addElement(new QName("repositoryDomain", nstenant));
 		rele.addAttribute("name", this.tenantSpec.getRepositoryDomain());
 		rele.addAttribute("storageName", this.tenantSpec.getStorageName());
-		rele.addAttribute("repositoryClient", this.tenantSpec.getRepoClient());
+                if (Tools.notEmpty(this.tenantSpec.getRepositoryName())) {
+		    rele.addAttribute("repositoryName", this.tenantSpec.getRepositoryName());
+                }
+		rele.addAttribute("repositoryClient", this.tenantSpec.getRepositoryClient());
 
 		// add in <tenant:properties> if required
 		makeProperties(ele);

--- a/cspi-services/src/main/java/org/collectionspace/chain/csp/persistence/services/TenantSpec.java
+++ b/cspi-services/src/main/java/org/collectionspace/chain/csp/persistence/services/TenantSpec.java
@@ -39,7 +39,8 @@ public class TenantSpec {
 	private String tenantId;
 	private String tenant, tenantDisplay, tenantVersion;
 	private String storageName;
-	private String repoClient;
+	private String repositoryName;
+	private String repositoryClient;
 	private String repositoryDomain;
 	private String indexHandler;
 	private Set<String> languages = new LinkedHashSet<String>();
@@ -54,7 +55,8 @@ public class TenantSpec {
 		tenantDisplay = Util.getStringOrDefault(section,"/tenant/display-name","CollectionSpace Demo");
 		tenantVersion = Util.getStringOrDefault(section,"/tenant/version","1.0");
 		storageName = Util.getStringOrDefault(section,"/repository/domain", repositoryDomain);
-		repoClient = Util.getStringOrDefault(section,"/repository/client", "nuxeo-java");
+		repositoryName = Util.getStringOrDefault(section,"/repository/name", "");
+		repositoryClient = Util.getStringOrDefault(section,"/repository/client", "nuxeo-java");
 		indexHandler = Util.getStringOrDefault(section,"/repository/indexHandler", DEFAULT_INDEX_HANDLER);
 		defaultlanguages.add("en");
 		defaultdateformats.add("MM/dd/yyyy");
@@ -106,12 +108,16 @@ public class TenantSpec {
 		return indexHandler;
 	}
 
-	public String getRepoClient(){
-		return repoClient;
+	public String getRepositoryClient(){
+		return repositoryClient;
 	}
 
 	public String getStorageName(){
 		return storageName;
+	}
+        
+        public String getRepositoryName(){
+		return repositoryName;
 	}
 
 	public String getTenant(){

--- a/tomcat-main/src/main/resources/tenants/lifesci/nightly-settings.xml
+++ b/tomcat-main/src/main/resources/tenants/lifesci/nightly-settings.xml
@@ -56,7 +56,8 @@
 				<display-name>Default tenant Lifesci</display-name>
 			</tenant>
 			<repository>
-				<domain>lifesci-domain</domain>
+                                <domain>lifesci_domain</domain>
+                                <name>lifesci_domain</name>
 				<client>nuxeo-java</client>
 				<dateformats>
 					<pattern>MM/dd/yyyy</pattern>

--- a/tomcat-main/src/main/resources/tenants/lifesci/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/lifesci/settings.xml
@@ -56,8 +56,8 @@
 				<display-name>Default tenant Lifesci</display-name>
 			</tenant>
 			<repository>
-				<domain>lifesci-domain</domain>
-				<repository></repository>
+				<domain>lifesci_domain</domain>
+				<name>lifesci_domain</name>
 				<client>nuxeo-java</client>
 				<dateformats>
 					<pattern>MM/dd/yyyy</pattern>


### PR DESCRIPTION
... value, needed to restore the ability to create per-tenant repositories. Change name of Lifesci tenant's repo, replacing a hyphen with an underscore, to match existing configuration and PostgreSQL conventions.
