### PR TITLE
CSPACE-4051: Use relative paths without hostnames for <ims-url> settings...

### DIFF
--- a/tomcat-main/src/main/resources/tenants/core/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/core/settings.xml
@@ -68,7 +68,7 @@
 				</languages>
 				<indexHandler>org.collectionspace.services.common.init.AddIndices</indexHandler>
 			</repository>
-			<ims-url>http://localhost:8180/collectionspace/tenant/core/</ims-url> <!-- XXX should be in separate IMS section -->
+			<ims-url>/collectionspace/tenant/core/</ims-url> <!-- XXX should be in separate IMS section -->
         </service>
     </persistence>
     <ui>

--- a/tomcat-main/src/main/resources/tenants/lifesci/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/lifesci/settings.xml
@@ -69,7 +69,7 @@
 				</languages>
 				<indexHandler>org.collectionspace.services.common.init.AddIndices</indexHandler>
 			</repository>
-			<ims-url>http://localhost:8180/collectionspace/tenant/lifesci/</ims-url> 
+			<ims-url>/collectionspace/tenant/lifesci/</ims-url> 
 			<!-- XXX should be in separate IMS section -->
         </service>
     </persistence>


### PR DESCRIPTION
... in two demonstration tenants, core and lifesci.
