### PR TITLE
CSPACE-5980: Adding Ray's contribution of a block in the <build> section...

### DIFF
--- a/tomcat-main/pom.xml
+++ b/tomcat-main/pom.xml
@@ -209,6 +209,20 @@
 	</dependencies>
 	<build>
 		<finalName>tomcat-main</finalName>
+		
+		<resources>
+			<resource>
+				<!-- Exclude config files, since these get deployed into tomcat's lib directory -->
+				<!-- by the deploy_cspace_config ant target (in ../war-entry/build.xml). -->
+				<directory>src/main/resources</directory>
+				<excludes>
+					<exclude>*-tenant.xml</exclude>
+					<exclude>defaults/**</exclude>
+					<exclude>tenants/**</exclude>
+				</excludes>
+			</resource>
+		</resources>
+
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
... of the tomcat-main POM to exclude App layer config files from being included in the App layer's WAR file. This means those files now will be read exclusively from Tomcat's lib directory.
