### PR TITLE
CSPACE-6334: Added Nuxeo's uid schema to the template doc-type-contrib.x...

### DIFF
--- a/tomcat-main/src/main/resources/nx-plugin-templates/doc-type-templates/OSGI-INF/doc-type-contrib.xml
+++ b/tomcat-main/src/main/resources/nx-plugin-templates/doc-type-templates/OSGI-INF/doc-type-contrib.xml
@@ -7,6 +7,7 @@
 		<doctype name="${NuxeoDocTypeName}" extends="${SchemaParentType}">
 			<schema name="common" />
 			<schema name="dublincore" />
+			<schema name="uid" />
 			${SchemaElements}
 			${PrefetchElement}
 		</doctype>


### PR DESCRIPTION
...ml file, used when generating Services artifacts. This template is needed, per Ray, to allow Nuxeo to autogenerate major and minor version numbers for versioned documents.
