### PR TITLE
Add CONTRIBUTING.md with links to developer docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+Contributions to CollectionSpace are generally welcome!
+
+See [Developing for CollectionSpace](https://collectionspace.atlassian.net/wiki/spaces/DOC/pages/1545308291/Developing+for+CollectionSpace)
+for developer documentation, including
+[Code Contribution Workflows](https://collectionspace.atlassian.net/wiki/spaces/DOC/pages/1955790932/Code+Contribution+Workflows).


### PR DESCRIPTION
It's a GitHub convention to have that information in a file with that
name.