### PR TITLE
Dryd 1049 materials vocab terms

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -124,7 +124,7 @@
 	<instance id="vocab-lostatus">
 		<web-url>loanoutstatus</web-url>
 		<title-ref>loanoutstatus</title-ref>
-		<title>loanedObjectStatus</title>
+		<title>Loaned Object Status</title>
 		<options>
 			<option>Requested</option>
 			<option>Authorized</option>
@@ -271,7 +271,7 @@
 	<instance id="vocab-persontermtype">
 		<web-url>persontermtype</web-url>
 		<title-ref>persontermtype</title-ref>
-		<title>personTermType</title>
+		<title>Person Term Type</title>
 		<options>
 			<option id="artist">Artist</option>
 			<option id="donor">Donor</option>
@@ -619,7 +619,7 @@
 	<instance id="vocab-materialuse">
 		<web-url>materialuse</web-url>
 		<title-ref>materialuse</title-ref>
-		<title>materialuse</title>
+		<title>Material Use</title>
 		<options>
 			<option id="cladding">cladding</option>
 			<option id="decking">decking</option>
@@ -646,7 +646,7 @@
 	<instance id="vocab-materialproductionrole">
 		<web-url>materialproductionrole</web-url>
 		<title-ref>materialproductionrole</title-ref>
-		<title>materialproductionrole</title>
+		<title>Material Production Role</title>
 		<options>
 			<option id="distributor">distributor</option>
 			<option id="manufacturer">manufacturer</option>
@@ -656,7 +656,7 @@
 	<instance id="vocab-materialresource">
 		<web-url>materialresource</web-url>
 		<title-ref>materialresource</title-ref>
-		<title>materialresource</title>
+		<title>Material Resource</title>
 		<options>
 			<option id="csi">CSI</option>
 			<option id="granta">Granta</option>
@@ -665,7 +665,7 @@
 	<instance id="vocab-materialform">
 		<web-url>materialform</web-url>
 		<title-ref>materialform</title-ref>
-		<title>materialform</title>
+		<title>Material Form</title>
 		<options>
 			<option id="aggregate">aggregate</option>
 			<option id="angle">angle</option>
@@ -705,7 +705,7 @@
 	<instance id="vocab-materialformtype">
 		<web-url>materialformtype</web-url>
 		<title-ref>materialformtype</title-ref>
-		<title>materialformtype</title>
+		<title>Material Form Type</title>
 		<options>
 			<option id="film">film</option>
 			<option id="sheet">sheet</option>
@@ -791,7 +791,7 @@
 	<instance id="vocab-electricalproperties">
 		<web-url>electricalproperties</web-url>
 		<title-ref>electricalproperties</title-ref>
-		<title>electricalproperties</title>
+		<title>Electrical Properties</title>
 		<options>
 			<option id="anti_static">anti-static</option>
 			<option id="electrical_resistivity_conductor">electrical resistivity - conductor</option>
@@ -980,7 +980,7 @@
 	<instance id="vocab-castingprocesses">
 		<web-url>castingprocesses</web-url>
 		<title-ref>castingprocesses</title-ref>
-		<title>castingprocesses</title>
+		<title>Casting Processes</title>
 		<options>
 			<option id="die_casting">die casting</option>
 			<option id="floating">floating</option>

--- a/tomcat-main/src/main/resources/defaults/cspace-vocabs.xml
+++ b/tomcat-main/src/main/resources/defaults/cspace-vocabs.xml
@@ -18,6 +18,6 @@
 	<instance id="vocab-publishto">
 		<web-url>publishto</web-url>
 		<title-ref>publishto</title-ref>
-		<title>Publishing destination</title>
+		<title>Publishing Destination</title>
 	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/defaults/extensions/fineart-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fineart-vocabularies.xml
@@ -4,15 +4,15 @@
 		<title-ref>cataloglevel</title-ref>
 		<title>Level of Cataloging</title>
 		<options>
-			<option id="item"> item </option>
-			<option id="volume"> volume </option>
-			<option id="group"> group </option>
-			<option id="subgroup"> subgroup </option>
-			<option id="collection"> collection </option>
-			<option id="series"> series </option>
-			<option id="set"> set </option>
-			<option id="multiples"> multiples </option>
-			<option id="component"> component </option>
+			<option id="item">item</option>
+			<option id="volume">volume</option>
+			<option id="group">group</option>
+			<option id="subgroup">subgroup</option>
+			<option id="collection">collection</option>
+			<option id="series">series</option>
+			<option id="set">set</option>
+			<option id="multiples">multiples</option>
+			<option id="component">component</option>
 		</options>
 	</instance>
 	<instance id="vocab-conceptrecordtype">
@@ -20,9 +20,9 @@
 		<title-ref>conceptrecordtype</title-ref>
 		<title>Concept Record Type</title>
 		<options>
-			<option id="concept"> concept</option>
+			<option id="concept">concept</option>
 			<option id="guideterm">guide term</option>
-			<option id="facet"> facet</option>
+			<option id="facet">facet</option>
 		</options>
 	</instance>
 	<instance id="vocab-othernameflags">
@@ -30,12 +30,12 @@
 		<title-ref>othernameflags</title-ref>
 		<title>Other Name Flags</title>
 		<options>
-			<option id="fullterm"> full term</option>
-			<option id="abbreviation"> abbreviation</option>
-			<option id="jargonslang"> jargon/slang</option>
-			<option id="scientificterm"> scientific term</option>
-			<option id="commonterm"> common term</option>
-			<option id="na"> not applicable</option>
+			<option id="fullterm">full term</option>
+			<option id="abbreviation">abbreviation</option>
+			<option id="jargonslang">jargon/slang</option>
+			<option id="scientificterm">scientific term</option>
+			<option id="commonterm">common term</option>
+			<option id="na">not applicable</option>
 		</options>
 	</instance>
 	<instance id="vocab-conceptrelationtype">

--- a/tomcat-main/src/main/resources/defaults/extensions/livingplant-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/livingplant-vocabularies.xml
@@ -20,7 +20,7 @@
 	<instance id="vocab-pestordiseaseobserved">
 		<web-url>pestordiseaseobserved</web-url>
 		<title-ref>pestordiseaseobserved</title-ref>
-		<title>Pest or disease observed</title>
+		<title>Pest or Disease Observed</title>
 		<options>
 			<option id="mites">Mites</option>
 			<option id="aphids">Aphids</option>

--- a/tomcat-main/src/main/resources/defaults/extensions/variablemedia-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/variablemedia-vocabularies.xml
@@ -27,19 +27,19 @@
 		<title>Condition Check Support</title>
 		<options>
 			<option id="8mm">8mm</option>
-			<option id="16mm"> 16mm</option>
-			<option id="35mm"> 35mm</option>
-			<option id="50mm"> 50mm</option>
-			<option id="onehalfinch"> 1/2 in.</option>
-			<option id="threequartersinch"> 3/4 in.</option>
-			<option id="twoinch"> 2 in.</option>
-			<option id="bluray"> Blu-ray disc</option>
-			<option id="cd"> CD</option>
+			<option id="16mm">16mm</option>
+			<option id="35mm">35mm</option>
+			<option id="50mm">50mm</option>
+			<option id="onehalfinch">1/2 in.</option>
+			<option id="threequartersinch">3/4 in.</option>
+			<option id="twoinch">2 in.</option>
+			<option id="bluray">Blu-ray disc</option>
+			<option id="cd">CD</option>
 			<option id="dvd">DVD</option>
-			<option id="floppydisk"> floppy disk</option>
-			<option id="laserdisc"> LaserDisc</option>
-			<option id="tapecassette"> tape cassette</option>
-			<option id="videocassette"> videocassette</option>
+			<option id="floppydisk">floppy disk</option>
+			<option id="laserdisc">LaserDisc</option>
+			<option id="tapecassette">tape cassette</option>
+			<option id="videocassette">videocassette</option>
 		</options>
 	</instance>
 	<instance id="vocab-contentworktype">
@@ -59,18 +59,18 @@
 		<title>Original Media Format</title>
 		<options>
 			<option id="8mm">8mm</option>
-			<option id="16mm"> 16mm</option>
-			<option id="35mm"> 35mm</option>
-			<option id="50mm"> 50mm</option>
-			<option id="onehalfinch"> 1/2 in.</option>
-			<option id="threequartersinch"> 3/4 in.</option>
-			<option id="twoinch"> 2 in.</option>
-			<option id="beta"> Bets</option>
-			<option id="dcc"> DCC</option>
+			<option id="16mm">16mm</option>
+			<option id="35mm">35mm</option>
+			<option id="50mm">50mm</option>
+			<option id="onehalfinch">1/2 in.</option>
+			<option id="threequartersinch">3/4 in.</option>
+			<option id="twoinch">2 in.</option>
+			<option id="beta">Bets</option>
+			<option id="dcc">DCC</option>
 			<option id="digibeta">Digibeta</option>
-			<option id="minidv"> MiniDV</option>
-			<option id="mp3"> MP3</option>
-			<option id="vhs"> VHS</option>
+			<option id="minidv">MiniDV</option>
+			<option id="mp3">MP3</option>
+			<option id="vhs">VHS</option>
 		</options>
 	</instance>
 	<instance id="vocab-origaudioformat">
@@ -78,14 +78,14 @@
 		<title-ref>originalaudioformat</title-ref>
 		<title>Original Audio Format</title>
 		<options>
-			<option id="aiff"> AIFF</option>
-			<option id="cassette"> cassette</option>
-			<option id="8track"> eight-track</option>
-			<option id="mp3"> MP3</option>
-			<option id="magnetictape"> magnetic tape</option>
-			<option id="reeltoreel"> reel-to-reel</option>
-			<option id="vinyl"> vinyl record</option>
-			<option id="wav"> WAV</option>
+			<option id="aiff">AIFF</option>
+			<option id="cassette">cassette</option>
+			<option id="8track">eight-track</option>
+			<option id="mp3">MP3</option>
+			<option id="magnetictape">magnetic tape</option>
+			<option id="reeltoreel">reel-to-reel</option>
+			<option id="vinyl">vinyl record</option>
+			<option id="wav">WAV</option>
 		</options>
 	</instance>
 	<instance id="vocab-programminglanguage">
@@ -94,15 +94,15 @@
 		<title>Programming languages</title>
 		<options>
 			<option id="clang">C (language)</option>
-			<option id="cplusplus"> C++</option>
-			<option id="csharp"> C#</option>
-			<option id="java"> Java</option>
-			<option id="javascript"> Javascript</option>
-			<option id="php"> Perl</option>
-			<option id="python"> PHP</option>
-			<option id="ruby"> Python</option>
-			<option id="sql"> Ruby</option>
-			<option id="digibeta"> SQL</option>
+			<option id="cplusplus">C++</option>
+			<option id="csharp">C#</option>
+			<option id="java">Java</option>
+			<option id="javascript">Javascript</option>
+			<option id="php">Perl</option>
+			<option id="python">PHP</option>
+			<option id="ruby">Python</option>
+			<option id="sql">Ruby</option>
+			<option id="digibeta">SQL</option>
 		</options>
 	</instance>
 	<instance id="vocab-authoringenvironment">
@@ -111,8 +111,8 @@
 		<title>Authoring Environment</title>
 		<options>
 			<option id="director">Director</option>
-			<option id="flash"> Flash</option>
-			<option id="shockwave"> Shockwave</option>
+			<option id="flash">Flash</option>
+			<option id="shockwave">Shockwave</option>
 		</options>
 	</instance>
 	<instance id="vocab-compressionsystem">
@@ -121,7 +121,7 @@
 		<title>Compression System</title>
 		<options>
 			<option id="dolby">Dolby</option>
-			<option id="mpeg"> MPEG</option>
+			<option id="mpeg">MPEG</option>
 		</options>
 	</instance>
 	<instance id="vocab-ratioformat">
@@ -130,10 +130,10 @@
 		<title>Ratio Format</title>
 		<options>
 			<option id="4x3">4:3</option>
-			<option id="3x2"> 3:2</option>
-			<option id="1618x1"> 1.618:1</option>
-			<option id="16x9"> 16:9</option>
-			<option id="185x1"> 1.85:1</option>
+			<option id="3x2">3:2</option>
+			<option id="1618x1">1.618:1</option>
+			<option id="16x9">16:9</option>
+			<option id="185x1">1.85:1</option>
 		</options>
 	</instance>
 	<instance id="vocab-screenresolution">
@@ -141,14 +141,14 @@
 		<title-ref>screenresolution</title-ref>
 		<title>Screen Resolution</title>
 		<options>
-			<option id="480i"> 480i</option>
-			<option id="480p"> 480p</option>
-			<option id="720p"> 720p</option>
-			<option id="1080i"> 1080i</option>
-			<option id="1080p"> 1080p</option>
-			<option id="1024x768"> 1024 x 768</option>
-			<option id="1366x768"> 1366 x 768</option>
-			<option id="1280x800"> 1280 x 800</option>
+			<option id="480i">480i</option>
+			<option id="480p">480p</option>
+			<option id="720p">720p</option>
+			<option id="1080i">1080i</option>
+			<option id="1080p">1080p</option>
+			<option id="1024x768">1024 x 768</option>
+			<option id="1366x768">1366 x 768</option>
+			<option id="1280x800">1280 x 800</option>
 		</options>
 	</instance>
 	<instance id="vocab-colorpalette">
@@ -157,7 +157,7 @@
 		<title>Color Palette</title>
 		<options>
 			<option id="cmyk">CMYK</option>
-			<option id="rgb"> RGB</option>
+			<option id="rgb">RGB</option>
 		</options>
 	</instance>
 	<instance id="vocab-creationhardware">
@@ -165,11 +165,11 @@
 		<title-ref>creationhardware</title-ref>
 		<title>Creation Hardware</title>
 		<options>
-			<option id="stillcamera"> still camera</option>
-			<option id="mobiledevice"> mobile device</option>
-			<option id="moviecamera"> movie camera</option>
-			<option id="taperecorder"> tape recorder</option>
-			<option id="webcam"> webcam</option>
+			<option id="stillcamera">still camera</option>
+			<option id="mobiledevice">mobile device</option>
+			<option id="moviecamera">movie camera</option>
+			<option id="taperecorder">tape recorder</option>
+			<option id="webcam">webcam</option>
 		</options>
 	</instance>
 	<instance id="vocab-playbackhardware">
@@ -178,13 +178,13 @@
 		<title>Playback Hardware</title>
 		<options>
 			<option id="bluray">Blu-ray video player</option>
-			<option id="cdplayer"> CD player</option>
-			<option id="computer"> computer</option>
-			<option id="dvdplayer">  DVD player</option>
-			<option id="laserdiscplayer">  LaserDisc player</option>
-			<option id="tapecassetteplayer">  tape cassette player</option>
-			<option id="television"> television set</option>
-			<option id="videocassetteplayer">  videocassette player</option>
+			<option id="cdplayer">CD player</option>
+			<option id="computer">computer</option>
+			<option id="dvdplayer">DVD player</option>
+			<option id="laserdiscplayer">LaserDisc player</option>
+			<option id="tapecassetteplayer">tape cassette player</option>
+			<option id="television">television set</option>
+			<option id="videocassetteplayer">videocassette player</option>
 		</options>
 	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -935,7 +935,7 @@
 	<instance id="vocab-mechanicalpropertyunits">
 		<web-url>mechanicalpropertyunits</web-url>
 		<title-ref>mechanicalpropertyunits</title-ref>
-		<title>Mechanical Propertyunits</title>
+		<title>Mechanical Property Units</title>
 		<options>
 			<option id="kg_per_m3">kg/m³</option>
 			<option id="MPa">MPa</option>

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -288,12 +288,18 @@
 		<title>Work Type</title>
 		<options>
 			<option id="built">Built</option>
+			<option id="course">Course</option>
+			<option id="dance">Dance</option>
+			<option id="exhibitioninstallation">Exhibition/Installation</option>
+			<option id="featuredapplication">Featured Application</option>
+			<option id="featuredcollection">Featured Collection</option>
 			<option id="movable">Movable</option>
 			<option id="movingimage">Moving Image</option>
-			<option id="dance">Dance</option>
-			<option id="theater">Theater</option>
-			<option id="performance">Performance</option>
 			<option id="music">Music</option>
+			<option id="namedcollection">Named Collection</option>
+			<option id="performance">Performance</option>
+			<option id="researchproject">Research Project</option>
+			<option id="theater">Theater</option>
 		</options>
 	</instance>
 	<instance id="vocab-workcreatortype">
@@ -301,13 +307,18 @@
 		<title-ref>workcreatortype</title-ref>
 		<title>Work Creator Type</title>
 		<options>
+			<option id="academicdepartment">Academic Department</option>
 			<option id="architect">Architect</option>
 			<option id="artist">Artist</option>
 			<option id="choreographer">Choreographer</option>
 			<option id="composer">Composer</option>
 			<option id="director">Director</option>
+			<option id="faculty">Faculty</option>
 			<option id="painter">Painter</option>
+			<option id="researcher">Researcher</option>
 			<option id="sculptor">Sculptor</option>
+			<option id="staff">Staff</option>
+			<option id="student">Student</option>
 			<option id="writer">Writer</option>
 		</options>
 	</instance>

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -54,7 +54,7 @@
 			<option id="faculty">faculty</option>
 			<option id="student">student</option>
 			<option id="independentscholar">independent scholar</option>
-			<option id="psuedouser">psuedo-user</option>
+			<option id="psuedouser">pseudo-user</option>
 			<option id="researchassistant">research assistant</option>
 			<option id="staff">staff</option>
 			<option id="summerschoolstudent">summer school student</option>

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -1,4 +1,5 @@
 <!-- Change options of organizationtype, uocmethods, uocusertypes, publishto. -->
+<!-- 2022-04-11 Change options for workcreatortype and worktype (DRYD-1049) -->
 <instances>
 	<include src="domain-instance-vocabularies.xml" strip-root="yes" />
 	<instance id="vocab-inventorystatus">


### PR DESCRIPTION
- Add terms as per [(DRYD-1049) Update Work Authority term lists for Materials profile](https://collectionspace.atlassian.net/browse/DRYD-1049)
- Make vocabulary title elements consistently human-readable (i.e. Person Term Types not personTermTypes, or Electrical Properties not electricalproperties). I did this in the defaults where applicable, assuming the changes would cascade down to profiles/tenants. 
- Remove leading/trailing spaces from vocabulary term values (i.e. `<option id="unknown"> unknown </option>`)
- Corrected a typo in term value (left the incorrect spelling in the option id attribute)