### PR TITLE
TimeBasedMedia fields for Cataloging

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -82,6 +82,32 @@
 			<field id="objectNameNote" />
 			<field id="objectName" mini="list" />
 		</repeat>
+		<repeat id="objectSignificanceGroupList/objectSignificanceGroup">
+			<field id="assignedSignificance" autocomplete="true" ui-type="enum"/>
+			<field id="significanceAssignedBy" autocomplete="true" ui-type="enum"/>
+			<field id="significanceAssignedDate" datatype="date"/>
+			<field id="significanceAssignedContact" autocomplete="true"/>
+		</repeat>
+		<field id="objectSuppliedBy" autocomplete="true"/>
+		<field id="objectComponentStatus" autocomplete="true" ui-type="enum"/>
+
+		<repeat id="objectCredentialGroupList/objectCredentialGroup">
+			<field id="credentialType" autocomplete="true" ui-type="enum" />
+			<field id="credentialRequiredForUse" autocomplete="true" ui-type="enum" />
+			<field id="credentialLocation" autocomplete="true" />
+		</repeat>
+
+		<repeat id="objectDistributedLedgerGroupList/objectDistributedLedgerGroup">
+			<field id="distributedStorageLedger" autocomplete="true" ui-type="enum" />
+			<field id="storageLedgerParentIdentifier" />
+			<field id="storageLedgerObjectIdentifier" />
+		</repeat>
+
+		<repeat id="objectLedgerGroupList/objectLedgerGroup" >
+			<field id="objectLedger" autocomplete="true" ui-type="enum" />
+			<field id="objectLedgerContactAddress" />
+			<field id="objectLedgerTokenID" />
+		</repeat>
 	</section>
 
 	<section id="descriptionInformation">

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -227,6 +227,8 @@
 			<field id="annotationDate" datatype="date" section="annotation" />
 			<field id="annotationAuthor" autocomplete="true" section="annotation" />
 		</repeat>
+
+		<field id="intendedBehavior" />
 	</section>
 	<section id="objectProductionInformation">
 		<repeat id="objectProductionDateGroupList/objectProductionDateGroup">

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -142,22 +142,22 @@
 		<field id="objectSuppliedBy" autocomplete="true"/>
 		<field id="objectComponentStatus" autocomplete="true" ui-type="enum"/>
 
-		<repeat id="objectCredentialGroupList/objectCredentialGroup">
+		<repeat id="credentialGroupList/credentialGroup">
 			<field id="credentialType" autocomplete="true" ui-type="enum" />
 			<field id="credentialRequiredForUse" autocomplete="true" ui-type="enum" />
 			<field id="credentialLocation" autocomplete="true" />
 		</repeat>
 
-		<repeat id="objectDistributedLedgerGroupList/objectDistributedLedgerGroup">
+		<repeat id="distributedLedgerGroupList/distributedLedgerGroup">
 			<field id="distributedStorageLedger" autocomplete="true" ui-type="enum" />
-			<field id="storageLedgerParentIdentifier" />
-			<field id="storageLedgerObjectIdentifier" />
+			<field id="distributedLedgerParentIdentifier" />
+			<field id="distributedLedgerObjectIdentifier" />
 		</repeat>
 
-		<repeat id="objectLedgerGroupList/objectLedgerGroup" >
-			<field id="objectLedger" autocomplete="true" ui-type="enum" />
-			<field id="objectLedgerContactAddress" />
-			<field id="objectLedgerTokenID" />
+		<repeat id="ledgerGroupList/ledgerGroup" >
+			<field id="ledger" autocomplete="true" ui-type="enum" />
+			<field id="ledgerContactAddress" />
+			<field id="ledgerTokenID" />
 		</repeat>
 	</section>
 

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -441,4 +441,28 @@
 			<field id="fieldColEventName" />
 		</repeat>
 	</section>
+
+	<section id="technicalSpecs">
+		<repeat id="avFormatGroupList/avFormatGroup">
+			<field id="formatType" autocomplete="true" ui-type="enum" />
+			<field id="format" autocomplete="true" ui-type="enum" />
+		</repeat>
+		<field id="numberOfChannels" datatype="integer" />
+		<repeat id="fileCodecGroupList/fileCodecGroup">
+			<field id="fileCodec" autocomplete="true" ui-type="enum" />
+			<field id="compressionStandard" autocomplete="true" ui-type="enum" />
+			<field id="fileContainer" autocomplete="true" ui-type="enum" />
+		</repeat>
+		<field id="audioType" autocomplete="true" ui-type="enum" />
+		<field id="audioPreferences" autocomplete="true" ui-type="enum" />
+		<repeat id="aspectRatioGroupList/aspectRatioGroup">
+			<field id="aspectRatio" autocomplete="true" ui-type="enum" />
+			<field id="aspectRatioType" autocomplete="true" ui-type="enum" />
+		</repeat>
+		<repeat id="colorSpaceGroupList/colorSpaceGroup">
+			<field id="colorSpace" autocomplete="true" ui-type="enum" />
+			<field id="colorType" autocomplete="true" ui-type="enum" />
+		</repeat>
+		<field id="avSpecificationNote" />
+	</section>
 </record>

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -28,6 +28,57 @@
 		<field id="nametitle" mini="summary,list" exists-in-services="false" service-field-alias="objectName" />
 	</section>
 
+	<section id="softwareTechSpecs">
+	  <repeat id="programmingLanguageGroupList/programmingLanguageGroup">
+			<field id="programmingLanguage" autocomplete="true" ui-type="enum" />
+			<field id="programmingLanguageVersion" autocomplete="true" ui-type="enum" />
+		</repeat>
+
+		<repeat id="libraries">
+			<field id="library" autocomplete="true" ui-type="enum" />
+		</repeat>
+
+		<repeat id="compilers">
+			<field id="compiler" autocomplete="true" ui-type="enum" />
+		</repeat>
+
+		<repeat id="intendedOperatingSystemGroupList/intendedOperatingSystemGroup">
+			<field id="intendedOperatingSystem" autocomplete="true" ui-type="enum" />
+			<field id="intendedOperatingSystemVersion" />
+		</repeat>
+
+		<repeat id="utilizedSoftwareGroupList/utilizedSoftwareGroup">
+			<field id="software" autocomplete="true" ui-type="enum" />
+			<field id="softwareVersion" />
+		</repeat>
+
+		<repeat id="intendedBrowserGroupList/intendedBrowserGroup">
+			<field id="intendedBrowser" autocomplete="true" ui-type="enum" />
+			<field id="intendedBrowserVersion" />
+		</repeat>
+
+		<repeat id="networkConnectionGroupList/networkConnectionGroup">
+			<field id="networkConnectionRequired" autocomplete="true" ui-type="enum" />
+			<field id="networkConnectionType" autocomplete="true" ui-type="enum" />
+		</repeat>
+
+		<repeat id="domainGroupList/domainGroup">
+			<field id="domainName" />
+			<field id="domainHost" autocomplete="true" ui-type="enum" />
+			<field id="domainType" autocomplete="true" ui-type="enum" />
+			<field id="domainVersion" autocomplete="true" ui-type="enum" />
+			<field id="domainOwner" autocomplete="true" ui-type="enum" />
+		</repeat>
+
+		<repeat id="applicationInteractionGroupList/applicationInteractionGroup">
+			<field id="applicationInteractionRequired" autocomplete="true" ui-type="enum" />
+			<field id="applicationRequired" autocomplete="true" ui-type="enum" />
+			<field id="applicationRequiredFor" />
+		</repeat>
+
+		<field id="apiUrl" />
+	</section>
+
 	<section id="identificationInformation">
 		<field id="objectNumber" mini="number,list" services-refnameDisplayName="true" />
 		<field id="numberOfObjects" datatype="integer" />

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -1436,4 +1436,101 @@
 			<option id="tezos">tezos</option>
 		</options>
 	</instance>
+	<instance id="vocab-programminglanguages">
+		<web-url>programminglanguages</web-url>
+		<title-ref>programminglanguages</title-ref>
+		<title>Programming Languages</title>
+		<options>
+			<option id="cpp">C++</option>
+			<option id="csharp">C#</option>
+			<option id="java">Java</option>
+			<option id="javascript">Javascript</option>
+			<option id="python">Python</option>
+			<option id="ruby">Ruby</option>
+		</options>
+	</instance>
+	<instance id="vocab-compilers">
+		<web-url>compilers</web-url>
+		<title-ref>compilers</title-ref>
+		<title>Compilers</title>
+		<options>
+			<option id="borlandturboc">Borland Turbo C</option>
+			<option id="gnuccompiler">GNU C Compiler</option>
+			<option id="psyco">Psyco</option>
+		</options>
+	</instance>
+	<instance id="vocab-utilizedsoftware">
+		<web-url>utilizedsoftware</web-url>
+		<title-ref>utilizedsoftware</title-ref>
+		<title>Utilized Software</title>
+		<options>
+			<option id="adobephotoshop">Adobe Photoshop</option>
+			<option id="blender">Blender</option>
+			<option id="finalcutpro">Final Cut Pro</option>
+		</options>
+	</instance>
+	<instance id="vocab-operatingsystems">
+		<web-url>operatingsystems</web-url>
+		<title-ref>operatingsystems</title-ref>
+		<title>Operating Systems</title>
+		<options>
+			<option id="Mac">Mac</option>
+			<option id="Linux">Linux</option>
+			<option id="Windows">Windows</option>
+		</options>
+	</instance>
+	<instance id="vocab-webbrowsers">
+		<web-url>webbrowsers</web-url>
+		<title-ref>webbrowsers</title-ref>
+		<title>Web Browsers</title>
+		<options>
+			<option id="Chrome">Chrome</option>
+			<option id="Edge">Edge</option>
+			<option id="Explorer">Explorer</option>
+			<option id="Firefox">Firefox</option>
+			<option id="Opera">Opera</option>
+			<option id="Safari">Safari</option>
+		</options>
+	</instance>
+	<instance id="vocab-required">
+		<web-url>required</web-url>
+		<title-ref>required</title-ref>
+		<title>Required Options</title>
+		<options>
+			<option id="yes">yes</option>
+			<option id="no">no</option>
+		</options>
+	</instance>
+	<instance id="vocab-softwarelibraries">
+		<web-url>softwarelibraries</web-url>
+		<title-ref>softwarelibraries</title-ref>
+		<title>Software Libraries</title>
+		<options>
+			<option id="placeholder">placeholder</option>
+		</options>
+	</instance>
+	<instance id="vocab-connectiontype">
+		<web-url>connectiontype</web-url>
+		<title-ref>connectiontype</title-ref>
+		<title>Connection Type</title>
+		<options>
+			<option id="placeholder">placeholder</option>
+		</options>
+	</instance>
+	<instance id="vocab-domaintype">
+		<web-url>domaintype</web-url>
+		<title-ref>domaintype</title-ref>
+		<title>Domain Type</title>
+		<options>
+			<option id="placeholder">placeholder</option>
+		</options>
+	</instance>
+	<instance id="vocab-requiredapplication">
+		<web-url>requiredapplication</web-url>
+		<title-ref>requiredapplication</title-ref>
+		<title>Required Application</title>
+		<options>
+			<option id="placeholder">placeholder</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -26,6 +26,8 @@
 			<option id="partiallydeaccessioned">partially deaccessioned</option>
 			<option id="partiallyexchanged">partially exchanged</option>
 			<option id="partiallyrecataloged">partially recataloged</option>
+			<option id="preacquisition">pre acquisition</option>
+			<option id="retired">retired</option>
 			<option id="returnedloanobject">returned loan object</option>
 			<option id="sold">sold</option>
 			<option id="stolen">stolen</option>
@@ -1351,6 +1353,87 @@
 			<option id="begin">begin</option>
 			<option id="end">end</option>
 			<option id="renewal">renewal</option>
+		</options>
+	</instance>
+	<instance id="vocab-assignedsignificance">
+		<web-url>assignedsignificance</web-url>
+		<title-ref>assignedsignificance</title-ref>
+		<title>Assigned Significance</title>
+		<options>
+			<option id="essential">essential</option>
+			<option id="dedicated">dedicated</option>
+			<option id="historical">historical</option>
+			<option id="nondedicated">non-dedicated</option>
+			<option id="iterative">iterative</option>
+			<option id="dependency">dependency</option>
+			<option id="retired">retired</option>
+		</options>
+	</instance>
+	<instance id="vocab-significanceassignedby">
+		<web-url>significanceassignedby</web-url>
+		<title-ref>significanceassignedby</title-ref>
+		<title>Significance Assigned By</title>
+		<options>
+			<option id="creator">creator</option>
+			<option id="museum">museum</option>
+		</options>
+	</instance>
+	<instance id="vocab-componentstatus">
+		<web-url>componentstatus</web-url>
+		<title-ref>componentstatus</title-ref>
+		<title>Component Status</title>
+		<options>
+			<option id="archival">archival</option>
+			<option id="exhibition">exhibition</option>
+			<option id="artistsuppliedarchival">artist supplied archival</option>
+			<option id="verifiedproof">verified proof</option>
+			<option id="researchcopy">research copy</option>
+			<option id="documentationcopy">documentationch copy</option>
+			<option id="duplicatingcopy">duplicating copy</option>
+			<option id="referencecopy">reference copy</option>
+			<option id="mezzaninefile">mezzanine file</option>
+			<option id="unique">unique</option>
+		</options>
+	</instance>
+	<instance id="vocab-credentialtype">
+		<web-url>credentialtype</web-url>
+		<title-ref>credentialtype</title-ref>
+		<title>Credential Type</title>
+		<options>
+			<option id="username">username</option>
+			<option id="password">password</option>
+			<option id="licensekey">license key</option>
+			<option id="accesscode">accesscode</option>
+		</options>
+	</instance>
+	<instance id="vocab-credentialrequiredforuse">
+		<web-url>credentialrequiredforuse</web-url>
+		<title-ref>credentialrequiredforuse</title-ref>
+		<title>Credential Required For Use</title>
+		<options>
+			<option id="yes">yes</option>
+			<option id="no">no</option>
+		</options>
+	</instance>
+	<instance id="vocab-distributedledgertype">
+		<web-url>distributedledgertype</web-url>
+		<title-ref>distributedledgertype</title-ref>
+		<title>Distributed Ledger Type</title>
+		<options>
+			<option id="ipfs">ipfs</option>
+			<option id="arweave">arweave</option>
+		</options>
+	</instance>
+	<instance id="vocab-ledgertype">
+		<web-url>ledgertype</web-url>
+		<title-ref>ledgertype</title-ref>
+		<title>Ledger Type</title>
+		<options>
+			<option id="ethereum">ethereum</option>
+			<option id="algorand">algorand</option>
+			<option id="polygon">polygon</option>
+			<option id="bitcoinlightning">bitcoin-lightning</option>
+			<option id="tezos">tezos</option>
 		</options>
 	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -1388,7 +1388,7 @@
 			<option id="artistsuppliedarchival">artist supplied archival</option>
 			<option id="verifiedproof">verified proof</option>
 			<option id="researchcopy">research copy</option>
-			<option id="documentationcopy">documentationch copy</option>
+			<option id="documentationcopy">documentation copy</option>
 			<option id="duplicatingcopy">duplicating copy</option>
 			<option id="referencecopy">reference copy</option>
 			<option id="mezzaninefile">mezzanine file</option>
@@ -1403,7 +1403,7 @@
 			<option id="username">username</option>
 			<option id="password">password</option>
 			<option id="licensekey">license key</option>
-			<option id="accesscode">accesscode</option>
+			<option id="accesscode">access code</option>
 		</options>
 	</instance>
 	<instance id="vocab-credentialrequiredforuse">
@@ -1589,10 +1589,10 @@
     <options>
       <option id="mono">mono</option>
       <option id="stereo">stereo</option>
-      <option id="doublemono">doublemono</option>
-      <option id="3channelmono">3channelmono</option>
-      <option id="quadraphonic">quadraphonic</option>
-      <option id="nosound">nosound</option>
+      <option id="doublemono">double mono</option>
+      <option id="3channelmono">3 channel mono</option>
+      <option id="quadrophonic">quadrophonic</option>
+      <option id="nosound">no sound</option>
       <option id="muted">muted</option>
     </options>
   </instance>

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -1533,4 +1533,114 @@
 			<option id="placeholder">placeholder</option>
 		</options>
 	</instance>
+  <instance id="vocab-formattypenames">
+    <web-url>formattypenames</web-url>
+    <title-ref>formattypenames</title-ref>
+    <title>Format Types</title>
+    <options>
+      <option id="audio">audio</option>
+      <option id="video">video</option>
+    </options>
+  </instance>
+  <instance id="vocab-formats">
+    <web-url>formats</web-url>
+    <title-ref>formats</title-ref>
+    <title>Formats</title>
+    <options>
+      <option id="analog">analog</option>
+      <option id="digital">digital</option>
+    </options>
+  </instance>
+  <instance id="vocab-filecodecs">
+    <web-url>filecodecs</web-url>
+    <title-ref>filecodecs</title-ref>
+    <title>File Codecs</title>
+    <options>
+      <option id="h264">h.264</option>
+      <option id="h265">h.265</option>
+      <option id="prores422">prores 422</option>
+      <option id="jpeg2000">jpeg 2000</option>
+      <option id="heacc">he aac</option>
+    </options>
+  </instance>
+  <instance id="vocab-compressionstandards">
+    <web-url>compressionstandards</web-url>
+    <title-ref>compressionstandards</title-ref>
+    <title>Compression Standards</title>
+    <options>
+      <option id="placeholder">placeholder</option>
+    </options>
+  </instance>
+  <instance id="vocab-filecontainers">
+    <web-url>filecontainers</web-url>
+    <title-ref>filecontainers</title-ref>
+    <title>File Containers</title>
+    <options>
+      <option id="mp4">mp4</option>
+      <option id="mov">mov</option>
+      <option id="wav">wav</option>
+      <option id="flac">flac</option>
+    </options>
+  </instance>
+  <instance id="vocab-audiotypes">
+    <web-url>audiotypes</web-url>
+    <title-ref>audiotypes</title-ref>
+    <title>Audio Types</title>
+    <options>
+      <option id="mono">mono</option>
+      <option id="stereo">stereo</option>
+      <option id="doublemono">doublemono</option>
+      <option id="3channelmono">3channelmono</option>
+      <option id="quadraphonic">quadraphonic</option>
+      <option id="nosound">nosound</option>
+      <option id="muted">muted</option>
+    </options>
+  </instance>
+  <instance id="vocab-audiopreferences">
+    <web-url>audiopreferences</web-url>
+    <title-ref>audiopreferences</title-ref>
+    <title>Audio Preferences</title>
+    <options>
+      <option id="headphones">headphones</option>
+      <option id="speakers">speakers</option>
+    </options>
+  </instance>
+  <instance id="vocab-aspectratios">
+    <web-url>aspectratios</web-url>
+    <title-ref>aspectratios</title-ref>
+    <title>Aspect Ratios</title>
+    <options>
+      <option id="1by1">1:1</option>
+      <option id="4by3">4:3</option>
+      <option id="16by9">16:9</option>
+    </options>
+  </instance>
+  <instance id="vocab-aspectratiotypes">
+    <web-url>aspectratiotypes</web-url>
+    <title-ref>aspectratiotypes</title-ref>
+    <title>Aspect Ratio Types</title>
+    <options>
+      <option id="image">image</option>
+      <option id="display">display</option>
+    </options>
+  </instance>
+  <instance id="vocab-colorspaces">
+    <web-url>colorspaces</web-url>
+    <title-ref>colorspaces</title-ref>
+    <title>Color Spaces</title>
+    <options>
+      <option id="cmyk">cmyk</option>
+      <option id="munsell">munsell</option>
+      <option id="pantone">pantone</option>
+      <option id="rgb">rgb</option>
+    </options>
+  </instance>
+  <instance id="vocab-colortypes">
+    <web-url>colortypes</web-url>
+    <title-ref>colortypes</title-ref>
+    <title>Color Types</title>
+    <options>
+      <option id="placeholder">placeholder</option>
+    </options>
+  </instance>
 </instances>

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -1406,15 +1406,6 @@
 			<option id="accesscode">access code</option>
 		</options>
 	</instance>
-	<instance id="vocab-credentialrequiredforuse">
-		<web-url>credentialrequiredforuse</web-url>
-		<title-ref>credentialrequiredforuse</title-ref>
-		<title>Credential Required For Use</title>
-		<options>
-			<option id="yes">yes</option>
-			<option id="no">no</option>
-		</options>
-	</instance>
 	<instance id="vocab-distributedledgertype">
 		<web-url>distributedledgertype</web-url>
 		<title-ref>distributedledgertype</title-ref>
@@ -1490,15 +1481,6 @@
 			<option id="Firefox">Firefox</option>
 			<option id="Opera">Opera</option>
 			<option id="Safari">Safari</option>
-		</options>
-	</instance>
-	<instance id="vocab-required">
-		<web-url>required</web-url>
-		<title-ref>required</title-ref>
-		<title>Required Options</title>
-		<options>
-			<option id="yes">yes</option>
-			<option id="no">no</option>
 		</options>
 	</instance>
 	<instance id="vocab-softwarelibraries">

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -826,7 +826,7 @@
 			<option id="artistsuppliedarchival">artist supplied archival</option>
 			<option id="verifiedproof">verified proof</option>
 			<option id="researchcopy">research copy</option>
-			<option id="documentationcopy">documentationch copy</option>
+			<option id="documentationcopy">documentation copy</option>
 			<option id="duplicatingcopy">duplicating copy</option>
 			<option id="referencecopy">reference copy</option>
 			<option id="mezzaninefile">mezzanine file</option>
@@ -841,7 +841,7 @@
 			<option id="username">username</option>
 			<option id="password">password</option>
 			<option id="licensekey">license key</option>
-			<option id="accesscode">accesscode</option>
+			<option id="accesscode">access code</option>
 		</options>
 	</instance>
 	<instance id="vocab-credentialrequiredforuse">
@@ -1027,10 +1027,10 @@
     <options>
       <option id="mono">mono</option>
       <option id="stereo">stereo</option>
-      <option id="doublemono">doublemono</option>
-      <option id="3channelmono">3channelmono</option>
-      <option id="quadraphonic">quadraphonic</option>
-      <option id="nosound">nosound</option>
+      <option id="doublemono">double mono</option>
+      <option id="3channelmono">3 channel mono</option>
+      <option id="quadrophonic">quadrophonic</option>
+      <option id="nosound">no sound</option>
       <option id="muted">muted</option>
     </options>
   </instance>
@@ -1081,5 +1081,4 @@
       <option id="placeholder">placeholder</option>
     </options>
   </instance>
-
 </instances>

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -971,4 +971,115 @@
 			<option id="placeholder">placeholder</option>
 		</options>
 	</instance>
+  <instance id="vocab-formattypenames">
+    <web-url>formattypenames</web-url>
+    <title-ref>formattypenames</title-ref>
+    <title>Format Types</title>
+    <options>
+      <option id="audio">audio</option>
+      <option id="video">video</option>
+    </options>
+  </instance>
+  <instance id="vocab-formats">
+    <web-url>formats</web-url>
+    <title-ref>formats</title-ref>
+    <title>Formats</title>
+    <options>
+      <option id="analog">analog</option>
+      <option id="digital">digital</option>
+    </options>
+  </instance>
+  <instance id="vocab-filecodecs">
+    <web-url>filecodecs</web-url>
+    <title-ref>filecodecs</title-ref>
+    <title>File Codecs</title>
+    <options>
+      <option id="h264">h.264</option>
+      <option id="h265">h.265</option>
+      <option id="prores422">prores 422</option>
+      <option id="jpeg2000">jpeg 2000</option>
+      <option id="heacc">he aac</option>
+    </options>
+  </instance>
+  <instance id="vocab-compressionstandards">
+    <web-url>compressionstandards</web-url>
+    <title-ref>compressionstandards</title-ref>
+    <title>Compression Standards</title>
+    <options>
+      <option id="placeholder">placeholder</option>
+    </options>
+  </instance>
+  <instance id="vocab-filecontainers">
+    <web-url>filecontainers</web-url>
+    <title-ref>filecontainers</title-ref>
+    <title>File Containers</title>
+    <options>
+      <option id="mp4">mp4</option>
+      <option id="mov">mov</option>
+      <option id="wav">wav</option>
+      <option id="flac">flac</option>
+    </options>
+  </instance>
+  <instance id="vocab-audiotypes">
+    <web-url>audiotypes</web-url>
+    <title-ref>audiotypes</title-ref>
+    <title>Audio Types</title>
+    <options>
+      <option id="mono">mono</option>
+      <option id="stereo">stereo</option>
+      <option id="doublemono">doublemono</option>
+      <option id="3channelmono">3channelmono</option>
+      <option id="quadraphonic">quadraphonic</option>
+      <option id="nosound">nosound</option>
+      <option id="muted">muted</option>
+    </options>
+  </instance>
+  <instance id="vocab-audiopreferences">
+    <web-url>audiopreferences</web-url>
+    <title-ref>audiopreferences</title-ref>
+    <title>Audio Preferences</title>
+    <options>
+      <option id="headphones">headphones</option>
+      <option id="speakers">speakers</option>
+    </options>
+  </instance>
+  <instance id="vocab-aspectratios">
+    <web-url>aspectratios</web-url>
+    <title-ref>aspectratios</title-ref>
+    <title>Aspect Ratios</title>
+    <options>
+      <option id="1by1">1:1</option>
+      <option id="4by3">4:3</option>
+      <option id="16by9">16:9</option>
+    </options>
+  </instance>
+  <instance id="vocab-aspectratiotypes">
+    <web-url>aspectratiotypes</web-url>
+    <title-ref>aspectratiotypes</title-ref>
+    <title>Aspect Ratio Types</title>
+    <options>
+      <option id="image">image</option>
+      <option id="display">display</option>
+    </options>
+  </instance>
+  <instance id="vocab-colorspaces">
+    <web-url>colorspaces</web-url>
+    <title-ref>colorspaces</title-ref>
+    <title>Color Spaces</title>
+    <options>
+      <option id="cmyk">cmyk</option>
+      <option id="munsell">munsell</option>
+      <option id="pantone">pantone</option>
+      <option id="rgb">rgb</option>
+    </options>
+  </instance>
+  <instance id="vocab-colortypes">
+    <web-url>colortypes</web-url>
+    <title-ref>colortypes</title-ref>
+    <title>Color Types</title>
+    <options>
+      <option id="placeholder">placeholder</option>
+    </options>
+  </instance>
+
 </instances>

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -26,6 +26,8 @@
 			<option id="partiallydeaccessioned">partially deaccessioned</option>
 			<option id="partiallyexchanged">partially exchanged</option>
 			<option id="partiallyrecataloged">partially recataloged</option>
+			<option id="preacquisition">pre acquisition</option>
+			<option id="retired">retired</option>
 			<option id="returnedloanobject">returned loan object</option>
 			<option id="sold">sold</option>
 			<option id="stolen">stolen</option>
@@ -789,6 +791,87 @@
 			<option id="begin">begin</option>
 			<option id="end">end</option>
 			<option id="renewal">renewal</option>
+		</options>
+	</instance>
+	<instance id="vocab-assignedsignificance">
+		<web-url>assignedsignificance</web-url>
+		<title-ref>assignedsignificance</title-ref>
+		<title>Assigned Significance</title>
+		<options>
+			<option id="essential">essential</option>
+			<option id="dedicated">dedicated</option>
+			<option id="historical">historical</option>
+			<option id="nondedicated">non-dedicated</option>
+			<option id="iterative">iterative</option>
+			<option id="dependency">dependency</option>
+			<option id="retired">retired</option>
+		</options>
+	</instance>
+	<instance id="vocab-significanceassignedby">
+		<web-url>significanceassignedby</web-url>
+		<title-ref>significanceassignedby</title-ref>
+		<title>Significance Assigned By</title>
+		<options>
+			<option id="creator">creator</option>
+			<option id="museum">museum</option>
+		</options>
+	</instance>
+	<instance id="vocab-componentstatus">
+		<web-url>componentstatus</web-url>
+		<title-ref>componentstatus</title-ref>
+		<title>Component Status</title>
+		<options>
+			<option id="archival">archival</option>
+			<option id="exhibition">exhibition</option>
+			<option id="artistsuppliedarchival">artist supplied archival</option>
+			<option id="verifiedproof">verified proof</option>
+			<option id="researchcopy">research copy</option>
+			<option id="documentationcopy">documentationch copy</option>
+			<option id="duplicatingcopy">duplicating copy</option>
+			<option id="referencecopy">reference copy</option>
+			<option id="mezzaninefile">mezzanine file</option>
+			<option id="unique">unique</option>
+		</options>
+	</instance>
+	<instance id="vocab-credentialtype">
+		<web-url>credentialtype</web-url>
+		<title-ref>credentialtype</title-ref>
+		<title>Credential Type</title>
+		<options>
+			<option id="username">username</option>
+			<option id="password">password</option>
+			<option id="licensekey">license key</option>
+			<option id="accesscode">accesscode</option>
+		</options>
+	</instance>
+	<instance id="vocab-credentialrequiredforuse">
+		<web-url>credentialrequiredforuse</web-url>
+		<title-ref>credentialrequiredforuse</title-ref>
+		<title>Credential Required For Use</title>
+		<options>
+			<option id="yes">yes</option>
+			<option id="no">no</option>
+		</options>
+	</instance>
+	<instance id="vocab-distributedledgertype">
+		<web-url>distributedledgertype</web-url>
+		<title-ref>distributedledgertype</title-ref>
+		<title>Distributed Ledger Type</title>
+		<options>
+			<option id="ipfs">ipfs</option>
+			<option id="arweave">arweave</option>
+		</options>
+	</instance>
+	<instance id="vocab-ledgertype">
+		<web-url>ledgertype</web-url>
+		<title-ref>ledgertype</title-ref>
+		<title>Ledger Type</title>
+		<options>
+			<option id="ethereum">ethereum</option>
+			<option id="algorand">algorand</option>
+			<option id="polygon">polygon</option>
+			<option id="bitcoinlightning">bitcoin-lightning</option>
+			<option id="tezos">tezos</option>
 		</options>
 	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -874,4 +874,101 @@
 			<option id="tezos">tezos</option>
 		</options>
 	</instance>
+	<instance id="vocab-programminglanguages">
+		<web-url>programminglanguages</web-url>
+		<title-ref>programminglanguages</title-ref>
+		<title>Programming Languages</title>
+		<options>
+			<option id="cpp">C++</option>
+			<option id="csharp">C#</option>
+			<option id="java">Java</option>
+			<option id="javascript">Javascript</option>
+			<option id="python">Python</option>
+			<option id="ruby">Ruby</option>
+		</options>
+	</instance>
+	<instance id="vocab-compilers">
+		<web-url>compilers</web-url>
+		<title-ref>compilers</title-ref>
+		<title>Compilers</title>
+		<options>
+			<option id="borlandturboc">Borland Turbo C</option>
+			<option id="gnuccompiler">GNU C Compiler</option>
+			<option id="psyco">Psyco</option>
+		</options>
+	</instance>
+	<instance id="vocab-utilizedsoftware">
+		<web-url>utilizedsoftware</web-url>
+		<title-ref>utilizedsoftware</title-ref>
+		<title>Utilized Software</title>
+		<options>
+			<option id="adobephotoshop">Adobe Photoshop</option>
+			<option id="blender">Blender</option>
+			<option id="finalcutpro">Final Cut Pro</option>
+		</options>
+	</instance>
+	<instance id="vocab-operatingsystems">
+		<web-url>operatingsystems</web-url>
+		<title-ref>operatingsystems</title-ref>
+		<title>Operating Systems</title>
+		<options>
+			<option id="Mac">Mac</option>
+			<option id="Linux">Linux</option>
+			<option id="Windows">Windows</option>
+		</options>
+	</instance>
+	<instance id="vocab-webbrowsers">
+		<web-url>webbrowsers</web-url>
+		<title-ref>webbrowsers</title-ref>
+		<title>Web Browsers</title>
+		<options>
+			<option id="Chrome">Chrome</option>
+			<option id="Edge">Edge</option>
+			<option id="Explorer">Explorer</option>
+			<option id="Firefox">Firefox</option>
+			<option id="Opera">Opera</option>
+			<option id="Safari">Safari</option>
+		</options>
+	</instance>
+	<instance id="vocab-required">
+		<web-url>required</web-url>
+		<title-ref>required</title-ref>
+		<title>Required Options</title>
+		<options>
+			<option id="yes">yes</option>
+			<option id="no">no</option>
+		</options>
+	</instance>
+	<instance id="vocab-softwarelibraries">
+		<web-url>softwarelibraries</web-url>
+		<title-ref>softwarelibraries</title-ref>
+		<title>Software Libraries</title>
+		<options>
+			<option id="placeholder">placeholder</option>
+		</options>
+	</instance>
+	<instance id="vocab-connectiontype">
+		<web-url>connectiontype</web-url>
+		<title-ref>connectiontype</title-ref>
+		<title>Connection Type</title>
+		<options>
+			<option id="placeholder">placeholder</option>
+		</options>
+	</instance>
+	<instance id="vocab-domaintype">
+		<web-url>domaintype</web-url>
+		<title-ref>domaintype</title-ref>
+		<title>Domain Type</title>
+		<options>
+			<option id="placeholder">placeholder</option>
+		</options>
+	</instance>
+	<instance id="vocab-requiredapplication">
+		<web-url>requiredapplication</web-url>
+		<title-ref>requiredapplication</title-ref>
+		<title>Required Application</title>
+		<options>
+			<option id="placeholder">placeholder</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -844,15 +844,6 @@
 			<option id="accesscode">access code</option>
 		</options>
 	</instance>
-	<instance id="vocab-credentialrequiredforuse">
-		<web-url>credentialrequiredforuse</web-url>
-		<title-ref>credentialrequiredforuse</title-ref>
-		<title>Credential Required For Use</title>
-		<options>
-			<option id="yes">yes</option>
-			<option id="no">no</option>
-		</options>
-	</instance>
 	<instance id="vocab-distributedledgertype">
 		<web-url>distributedledgertype</web-url>
 		<title-ref>distributedledgertype</title-ref>
@@ -928,15 +919,6 @@
 			<option id="Firefox">Firefox</option>
 			<option id="Opera">Opera</option>
 			<option id="Safari">Safari</option>
-		</options>
-	</instance>
-	<instance id="vocab-required">
-		<web-url>required</web-url>
-		<title-ref>required</title-ref>
-		<title>Required Options</title>
-		<options>
-			<option id="yes">yes</option>
-			<option id="no">no</option>
 		</options>
 	</instance>
 	<instance id="vocab-softwarelibraries">


### PR DESCRIPTION
Fields + vocab defined in:
* https://collectionspace.atlassian.net/browse/DRYD-1034
* https://collectionspace.atlassian.net/browse/DRYD-1039
* https://collectionspace.atlassian.net/browse/DRYD-1040
* https://collectionspace.atlassian.net/browse/DRYD-1041

# Notes

There are still some missing vocabulary entries in the specs from the epic (https://collectionspace.atlassian.net/browse/DRYD-1033), so I've only added placeholders for them. These are: `softwarelibraries`, `connectiontype`, `domaintype`, `requiredapplication`, `compressionstandards`, and `colortypes`.

There's also a controlled list defined in the spec for saying something is required, which is typically just a yes/no. I was considering just using a single vocab item for this but wasn't sure what is preferred.