### PR TITLE
DRYD-1133: Chronology Authority

### DIFF
--- a/tomcat-main/src/main/resources/core-tenant.xml
+++ b/tomcat-main/src/main/resources/core-tenant.xml
@@ -50,6 +50,8 @@
 			<!-- include src="base-authority-taxon-termList.xml"/ -->
             <!-- include src="base-authority-taxon.xml"/ -->
 
+			<include src="base-authority-chronology-termList.xml" />
+			<include src="base-authority-chronology.xml" />
 			<include src="base-authority-concept-termList.xml" />
 			<include src="base-authority-concept.xml" />
 			<include src="base-authority-work-termList.xml" />

--- a/tomcat-main/src/main/resources/defaults/base-authority-chronology-termList.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-chronology-termList.xml
@@ -1,0 +1,20 @@
+<record id="preferredChronology" in-recordlist="no" separate-record="false">
+  <section id="termInformation">
+		<repeat id="chronologyTermGroupList/chronologyTermGroup">
+			<!-- Fields common across all authority items -->
+			<field id="termDisplayName" mini="summary,number,list" services-should-index="true" />
+			<field id="termName" />
+			<field id="termType" autocomplete="true" ui-type="enum" />
+			<field id="termFlag" autocomplete="true" ui-type="enum" />
+			<field id="termStatus" mini="list" />
+			<field id="termQualifier" />
+			<field id="termLanguage" autocomplete="true" ui-type="enum" />
+			<field id="termPrefForLang" datatype="boolean" />
+			<field id="termSource" autocomplete="true" />
+			<field id="termSourceDetail" />
+			<field id="termSourceID" />
+			<field id="termSourceNote" />
+			<field id="termFormattedDisplayName" />
+    </repeat>
+  </section>
+</record>

--- a/tomcat-main/src/main/resources/defaults/base-authority-chronology-termList.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-chronology-termList.xml
@@ -1,20 +1,22 @@
 <record id="preferredChronology" in-recordlist="no" separate-record="false">
   <section id="termInformation">
-		<repeat id="chronologyTermGroupList/chronologyTermGroup">
-			<!-- Fields common across all authority items -->
-			<field id="termDisplayName" mini="summary,number,list" services-should-index="true" />
-			<field id="termName" />
-			<field id="termType" autocomplete="true" ui-type="enum" />
-			<field id="termFlag" autocomplete="true" ui-type="enum" />
-			<field id="termStatus" mini="list" />
-			<field id="termQualifier" />
-			<field id="termLanguage" autocomplete="true" ui-type="enum" />
-			<field id="termPrefForLang" datatype="boolean" />
-			<field id="termSource" autocomplete="true" />
-			<field id="termSourceDetail" />
-			<field id="termSourceID" />
-			<field id="termSourceNote" />
-			<field id="termFormattedDisplayName" />
+    <repeat id="chronologyTermGroupList/chronologyTermGroup">
+      <!-- Fields common across all authority items -->
+      <field id="termDisplayName" mini="summary,number,list" services-should-index="true" />
+      <field id="termName" />
+      <field id="termType" autocomplete="true" ui-type="enum" />
+      <field id="termFlag" autocomplete="true" ui-type="enum" />
+      <field id="termStatus" mini="list" />
+      <field id="termQualifier" />
+      <field id="termLanguage" autocomplete="true" ui-type="enum" />
+      <field id="termPrefForLang" datatype="boolean" />
+      <field id="termSource" autocomplete="true" />
+      <field id="termSourceDetail" />
+      <field id="termSourceID" />
+      <field id="termSourceNote" />
+      <field id="termFormattedDisplayName" />
+      <!-- Fields specific to chronology terms -->
+      <field id="historicalStatus" />
     </repeat>
   </section>
 </record>

--- a/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
@@ -1,14 +1,14 @@
-<record id="chronology" type="authority" cms-type="default" generate-services-schema="true" >
-	<terms-used>true</terms-used>
-	<web-url>chronology</web-url>
+<record id="chronology" type="authority" cms-type="default" generate-services-schema="true">
+  <terms-used>true</terms-used>
+  <web-url>chronology</web-url>
 
   <services-tenant-auth-plural>Chronologyauthorities</services-tenant-auth-plural>
   <services-tenant-auth-singular>Chronologyauthority</services-tenant-auth-singular>
   <services-tenant-singular>Chronology</services-tenant-singular>
   <services-tenant-plural>Chronologies</services-tenant-plural>
 
-	<services-instances-path>chronologyauthorities_common:http://collectionspace.org/services/chronology,abstract-common-list/list-item</services-instances-path>
-	<services-single-instance-path>chronologyauthorities_common:http://collectionspace.org/services/chronology,chronologyauthorities_common</services-single-instance-path>
+  <services-instances-path>chronologyauthorities_common:http://collectionspace.org/services/chronology,abstract-common-list/list-item</services-instances-path>
+  <services-single-instance-path>chronologyauthorities_common:http://collectionspace.org/services/chronology,chronologyauthorities_common</services-single-instance-path>
   <services-list-path>http://collectionspace.org/services/chronology,abstract-common-list/list-item</services-list-path>
 
   <services-record-path>chronologies_common:http://collectionspace.org/services/chronology,chronologies_common</services-record-path>
@@ -17,23 +17,31 @@
   <services-url>chronologyauthorities</services-url>
   <authority-vocab-type>ChronologyAuthority</authority-vocab-type>
 
+  <structures>
+    <structure id="screen">
+      <view>
+        <hierarchy-section show="true" />
+      </view>
+    </structure>
+  </structures>
+
   <include src="domain-authority-chronology.xml" strip-root="yes" />
 
   <instances id="chronology">
     <instance id="chronology-era">
       <web-url>era</web-url>
       <title-ref>era</title-ref>
-      <title>Era Chronology</title>
+      <title>Era Chronologies</title>
     </instance>
     <instance id="chronology-event">
       <web-url>event</web-url>
       <title-ref>event</title-ref>
-      <title>Event Chronology</title>
+      <title>Event Chronologies</title>
     </instance>
-    <instance id="chronology-fieldcollection">
-      <web-url>fieldcollection</web-url>
-      <title-ref>fieldcollection</title-ref>
-      <title>Field Collection Chronology</title>
+    <instance id="chronology-field_collection">
+      <web-url>field_collection</web-url>
+      <title-ref>field_collection</title-ref>
+      <title>Field Collection Chronologies</title>
     </instance>
   </instances>
 
@@ -42,21 +50,106 @@
   </section>
 
   <section id="chronologyInformation">
-		<field id="preferredChronology" ui-type="groupfield/preferredChronology/selfrenderer" />
+    <field id="preferredChronology" ui-type="groupfield/preferredChronology/selfrenderer" />
+
+    <field id="chronologyDateStructuredDateGroup" ui-type="groupfield/structureddate" />
+    <repeat id="chronologyPlaces">
+      <field id="chronologyPlace" autocomplete="true" />
+    </repeat>
+    <field id="chronologyType" autocomplete="true" ui-type="enum" />
+    <field id="chronologyNote" />
+    <field id="chronologyDescription" />
+
+    <repeat id="identifierGroupList/identifierGroup">
+      <field id="identifierValue" />
+      <field id="identifierCitation" autocomplete="true" ui-type="enum" />
+      <field id="identifierDate" />
+    </repeat>
+
+    <repeat id="otherDateGroupList/otherDateGroup">
+      <field id="otherDateStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="otherDatePlaces">
+        <field id="otherDatePlace" autocomplete="true" />
+      </repeat>
+      <repeat id="otherDateCitations">
+        <field id="otherDateCitation" autocomplete="true" />
+      </repeat>
+      <field id="otherDateNote" />
+    </repeat>
+
+    <repeat id="personGroupList/personGroup">
+      <field id="person" autocomplete="true" />
+      <field id="personType" autocomplete="true" ui-type="enum" />
+      <field id="personStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="personCitations">
+        <field id="personCitation" autocomplete="true" />
+      </repeat>
+      <field id="personNote" />
+    </repeat>
+
+    <repeat id="peopleGroupList/peopleGroup">
+      <field id="people" autocomplete="true" />
+      <field id="peopleType" autocomplete="true" ui-type="enum" />
+      <field id="peopleStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="peopleCitations">
+        <field id="peopleCitation" autocomplete="true" />
+      </repeat>
+      <field id="peopleNote" />
+    </repeat>
+
+    <repeat id="organizationGroupList/organizationGroup">
+      <field id="organization" autocomplete="true" />
+      <field id="organizationType" autocomplete="true" ui-type="enum" />
+      <field id="organizationStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="organizationCitations">
+        <field id="organizationCitation" autocomplete="true" />
+      </repeat>
+      <field id="organizationNote" />
+    </repeat>
+
+    <repeat id="conceptGroupList/conceptGroup">
+      <field id="concept" autocomplete="true" />
+      <field id="conceptType" autocomplete="true" ui-type="enum" />
+      <field id="conceptStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="conceptCitations">
+        <field id="conceptCitation" autocomplete="true" />
+      </repeat>
+      <field id="conceptNote" />
+    </repeat>
+
+    <repeat id="placeGroupList/placeGroup">
+      <field id="place" autocomplete="true" />
+      <field id="placeType" autocomplete="true" ui-type="enum" />
+      <field id="placeStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="placeCitations">
+        <field id="placeCitation" autocomplete="true" />
+      </repeat>
+      <field id="placeNote" />
+    </repeat>
+
+    <repeat id="relatedPeriodGroupList/relatedPeriodGroup">
+      <field id="relatedPeriod" autocomplete="true" />
+      <field id="relatedPeriodType" autocomplete="true" ui-type="enum" />
+      <field id="relatedPeriodStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="relatedPeriodCitations">
+        <field id="relatedPeriodCitation" autocomplete="true" />
+      </repeat>
+      <field id="relatedPeriodNote" />
+    </repeat>
   </section>
 
-	<!-- not used in UI except in autocompletes -->
-	<section id="otherInformation">
-		<field id="inAuthority" services-should-index="true" />
-		<field id="deprecatedRefName">
-			<services-tag>refName</services-tag>
-		</field>
-		<field id="shortIdentifier" mini="list" services-should-index="true" />
-		<field id="csid" exists-in-services="false" mini="list" />
-		<!-- SAS related fields -->
-		<field id="rev" mini="list" datatype="integer" />
-		<field id="sas" mini="list" datatype="boolean" />
-		<field id="proposed" mini="list" datatype="boolean" />
-		<field id="deprecated" mini="list" datatype="boolean" />
-	</section>
+  <!-- not used in UI except in autocompletes -->
+  <section id="otherInformation">
+    <field id="inAuthority" services-should-index="true" />
+    <field id="deprecatedRefName">
+      <services-tag>refName</services-tag>
+    </field>
+    <field id="shortIdentifier" mini="list" services-should-index="true" />
+    <field id="csid" exists-in-services="false" mini="list" />
+    <!-- SAS related fields -->
+    <field id="rev" mini="list" datatype="integer" />
+    <field id="sas" mini="list" datatype="boolean" />
+    <field id="proposed" mini="list" datatype="boolean" />
+    <field id="deprecated" mini="list" datatype="boolean" />
+  </section>
 </record>

--- a/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
@@ -1,0 +1,62 @@
+<record id="chronology" type="authority" cms-type="default" generate-services-schema="true" >
+	<terms-used>true</terms-used>
+	<web-url>chronology</web-url>
+
+  <services-tenant-auth-plural>Chronologyauthorities</services-tenant-auth-plural>
+  <services-tenant-auth-singular>Chronologyauthority</services-tenant-auth-singular>
+  <services-tenant-singular>Chronology</services-tenant-singular>
+  <services-tenant-plural>Chronologies</services-tenant-plural>
+
+	<services-instances-path>chronologyauthorities_common:http://collectionspace.org/services/chronology,abstract-common-list/list-item</services-instances-path>
+	<services-single-instance-path>chronologyauthorities_common:http://collectionspace.org/services/chronology,chronologyauthorities_common</services-single-instance-path>
+  <services-list-path>http://collectionspace.org/services/chronology,abstract-common-list/list-item</services-list-path>
+
+  <services-record-path>chronologies_common:http://collectionspace.org/services/chronology,chronologies_common</services-record-path>
+  <services-record-path id="collectionspace_core">collectionspace_core:http://collectionspace.org/collectionspace_core/,collectionspace_core</services-record-path>
+
+  <services-url>chronologyauthorities</services-url>
+  <authority-vocab-type>ChronologyAuthority</authority-vocab-type>
+
+  <include src="domain-authority-chronology.xml" strip-root="yes" />
+
+  <instances id="chronology">
+    <instance id="chronology-era">
+      <web-url>era</web-url>
+      <title-ref>era</title-ref>
+      <title>Era Chronology</title>
+    </instance>
+    <instance id="chronology-event">
+      <web-url>event</web-url>
+      <title-ref>event</title-ref>
+      <title>Event Chronology</title>
+    </instance>
+    <instance id="chronology-fieldcollection">
+      <web-url>fieldcollection</web-url>
+      <title-ref>fieldcollection</title-ref>
+      <title>Field Collection Chronology</title>
+    </instance>
+  </instances>
+
+  <section id="coreInformation">
+    <include src="core-fields.xml" strip-root="yes" />
+  </section>
+
+  <section id="chronologyInformation">
+		<field id="preferredChronology" ui-type="groupfield/preferredChronology/selfrenderer" />
+  </section>
+
+	<!-- not used in UI except in autocompletes -->
+	<section id="otherInformation">
+		<field id="inAuthority" services-should-index="true" />
+		<field id="deprecatedRefName">
+			<services-tag>refName</services-tag>
+		</field>
+		<field id="shortIdentifier" mini="list" services-should-index="true" />
+		<field id="csid" exists-in-services="false" mini="list" />
+		<!-- SAS related fields -->
+		<field id="rev" mini="list" datatype="integer" />
+		<field id="sas" mini="list" datatype="boolean" />
+		<field id="proposed" mini="list" datatype="boolean" />
+		<field id="deprecated" mini="list" datatype="boolean" />
+	</section>
+</record>

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -1960,4 +1960,103 @@
 			<option id="photocopying_not_allowed">Photocopying not allowed</option>
 		</options>
 	</instance>
+	<instance id="vocab-chronologytermtype">
+		<web-url>chronologytermtype</web-url>
+		<title-ref>chronologytermtype</title-ref>
+		<title>Chronology Term Type</title>
+		<options>
+			<option id="placeholder">placeholder</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytermflag">
+		<web-url>chronologytermflag</web-url>
+		<title-ref>chronologytermflag</title-ref>
+		<title>Chronology Term Flag</title>
+		<options>
+			<option id="placeholder">placeholder</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytermstatus">
+		<web-url>chronologytermstatus</web-url>
+		<title-ref>chronologytermstatus</title-ref>
+		<title>Chronology Term Status</title>
+		<options>
+			<option id="placeholder">placeholder</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyhistoricalstatus">
+		<web-url>chronologyhistoricalstatus</web-url>
+		<title-ref>chronologyhistoricalstatus</title-ref>
+		<title>Chronology Historical Status</title>
+		<options>
+			<option id="placeholder">placeholder</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytypes">
+		<web-url>chronologytypes</web-url>
+		<title-ref>chronologytypes</title-ref>
+		<title>Chronology Types</title>
+		<options>
+			<option id="archaeological_period">archaeological period</option>
+			<option id="dynasty">dynasty</option>
+			<option id="collection_activity">collection activity</option>
+			<option id="olympic_games">olympic games</option>
+			<option id="summer_games">summer games</option>
+			<option id="game_event">game event</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologypersonrelations">
+		<web-url>chronologypersonrelations</web-url>
+		<title-ref>chronologypersonrelations</title-ref>
+		<title>Chronology Person Relations</title>
+		<options>
+			<option id="monarch">monarch</option>
+			<option id="project_director">project director</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologypeoplerelations">
+		<web-url>chronologypeoplerelations</web-url>
+		<title-ref>chronologypeoplerelations</title-ref>
+		<title>Chronology People Relations</title>
+		<options>
+			<option id="placeholder">placeholder</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyorganizationrelations">
+		<web-url>chronologyorganizationrelations</web-url>
+		<title-ref>chronologyorganizationrelations</title-ref>
+		<title>Chronology Organization Relations</title>
+		<options>
+			<option id="sponsor">sponsor</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyconceptrelations">
+		<web-url>chronologyconceptrelations</web-url>
+		<title-ref>chronologyconceptrelations</title-ref>
+		<title>Chronology Concept Relations</title>
+		<options>
+			<option id="event_sport">event sport</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyplacerelations">
+		<web-url>chronologyplacerelations</web-url>
+		<title-ref>chronologyplacerelations</title-ref>
+		<title>Chronology Place Relations</title>
+		<options>
+			<option id="capital">capital</option>
+			<option id="modern_area">modern area</option>
+			<option id="main_location">main location</option>
+			<option id="additional_location">additional location</option>
+			<option id="venue">venue</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyrelations">
+		<web-url>chronologyrelations</web-url>
+		<title-ref>chronologyrelations</title-ref>
+		<title>Chronology Relations</title>
+		<options>
+			<option id="follows">follows</option>
+			<option id="followed_by">followed by</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/defaults/domain-authority-chronology.xml
+++ b/tomcat-main/src/main/resources/defaults/domain-authority-chronology.xml
@@ -1,0 +1,4 @@
+<root>
+  <section id="domaindata">
+  </section>
+</root>


### PR DESCRIPTION
**What does this do?**
Creates a new Chronology Authority

**Why are we doing this? (with JIRA link)**
https://collectionspace.atlassian.net/browse/DRYD-1133
_Note: Specs are in DRYD-1134_

This new authority allows records to reference eras (e.g. archaeological, geological, historical, etc) and events (e.g. presidential terms, wars, olympic games, etc).

**How should this be tested? Do these changes have associated tests?**

* Verify that cspace is able to build and deploy;
* Once the server is running check that the authority and vocabularies are able to be queried, e.g.
  * curl -u 'admin@core.collectionspace.org:Administrator' http://localhost:8180/cspace-services/chronologyauthorities
  * curl -u 'admin@core.collectionspace.org:Administrator' 'http://localhost:8180/cspace-services/vocabularies/urn:cspace:name(chronologytermstatus)'
* Testing of adding, retrieving, and searching authorities can be done with cspace-ui

**Dependencies for merging? Releasing to production?**
Needs vocabularies to be defined before merging.

Related prs for adding Chronology to the cspace-ui and services layers

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter ran and tested against a local instance
