### PR TITLE
DRYD-1211: Add nagpra note field

### DIFF
--- a/tomcat-main/src/main/resources/defaults/extensions/nagpra-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/nagpra-collectionobject.xml
@@ -18,6 +18,10 @@
 			<field id="repatriationNote" section="nagpra" />
 		</repeat>
 
+		<repeat id="nagpraNotes" section="nagpra">
+			<field id="nagpraNote" section="nagpra" />
+		</repeat>
+
 		<repeat id="nagpraCulturalDeterminations" section="nagpra">
 			<field id="nagpraCulturalDetermination" section="nagpra" />
 		</repeat>


### PR DESCRIPTION
**What does this do?**
Add repeatable field for notes to the nagpra collection object extension

**Why are we doing this? (with JIRA link)**
https://collectionspace.atlassian.net/browse/DRYD-1211

Allows capturing of generic notes for NAGPRA objects.

**How should this be tested? Do these changes have associated tests?**

Using the PR from cspace-ui-plugin-ext-nagpra.js and the athro ui plugin:
* Build collection space with the `anthro` tenant enabled from this PR
* Build the PR for the nagpra ui extension: `npm run build`
* Copy the dist directory from the ui extension into the anthro node_modules, e.g. `node_modules/cspace-ui-plugin-ext-nagpra.js`
  * Side note - not sure if there's a better/easier way of doing this but it's how I've been testing changes for the ui projects
* Run the anthro ui profile with `npm run devserver`
* Create a new collection object and add a note to the `NAGPRA notes`

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance