### PR TITLE
DRYD-1133: Add chronology fields to collectionobject

### DIFF
--- a/tomcat-main/src/main/resources/anthro-tenant.xml
+++ b/tomcat-main/src/main/resources/anthro-tenant.xml
@@ -53,6 +53,8 @@
 			<include src="base-authority-concept.xml,anthro-authority-concept.xml" merge="xmlmerge.properties" />
 			<include src="base-authority-work-termList.xml" />
 			<include src="base-authority-work.xml" />
+			<include src="base-authority-chronology-termList.xml" />
+			<include src="base-authority-chronology.xml" />
 
 			<include src="base-vocabularies.xml" />
 

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -303,6 +303,10 @@
 			<group id="objectProductionDate" ui-type="groupfield/structureddate" />
 		</repeat>
 
+		<repeat id="objectProductionEras">
+			<field id="objectProductionEra" autocomplete="true" />
+		</repeat>
+
 		<repeat id="techniqueGroupList/techniqueGroup">
 			<field id="technique" />
 			<field id="techniqueType" />
@@ -393,6 +397,10 @@
 			</repeat>
 			<field id="assocEventName" />
 			<field id="assocEventNameType" />
+
+			<field id="assocControlledEventName" />
+			<field id="assocControlledEventNameType" />
+
 			<repeat id="assocEventOrganizations">
 				<field id="assocEventOrganization" autocomplete="true" />
 			</repeat>

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -398,7 +398,7 @@
 			<field id="assocEventName" />
 			<field id="assocEventNameType" />
 
-			<field id="assocEvent" />
+			<field id="assocEvent" autocomplete="true" />
 			<field id="assocEventType" />
 
 			<repeat id="assocEventOrganizations">

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -398,8 +398,8 @@
 			<field id="assocEventName" />
 			<field id="assocEventNameType" />
 
-			<field id="assocControlledEventName" />
-			<field id="assocControlledEventNameType" />
+			<field id="assocEvent" />
+			<field id="assocEventType" />
 
 			<repeat id="assocEventOrganizations">
 				<field id="assocEventOrganization" autocomplete="true" />

--- a/tomcat-main/src/main/resources/tenants/anthro/anthro-collectionobject.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/anthro-collectionobject.xml
@@ -86,6 +86,9 @@
 
 	<section id="objectCollectionInformation">
 		<field id="fieldLocVerbatim" section="anthro" />
+		<repeat id="fieldCollectionControlledEvents" section="anthro">
+			<field id="fieldCollectionControlledEvent" autocomplete="true" section="anthro" />
+		</repeat>
 	</section>
 
 	<section id="localityInformation">

--- a/tomcat-main/src/main/resources/tenants/anthro/anthro-collectionobject.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/anthro-collectionobject.xml
@@ -86,8 +86,8 @@
 
 	<section id="objectCollectionInformation">
 		<field id="fieldLocVerbatim" section="anthro" />
-		<repeat id="fieldCollectionControlledEvents" section="anthro">
-			<field id="fieldCollectionControlledEvent" autocomplete="true" section="anthro" />
+		<repeat id="fieldCollectionEvents" section="anthro">
+			<field id="fieldCollectionEvent" autocomplete="true" section="anthro" />
 		</repeat>
 	</section>
 


### PR DESCRIPTION
**What does this do?**

Enable Chronology for the Anthro profile
Adds fields to CollectionObject which will use the Chronology authority

**Why are we doing this? (with JIRA link)**
The fields are defined in the spec for [DRYD-1133](https://collectionspace.atlassian.net/jira/software/c/projects/DRYD/issues/DRYD-1133).

**How should this be tested? Do these changes have associated tests?**
* Build collectionspace
* Using the adjacent PR from cspace-ui, try to create and save a collectionobject with new fields:
  * objectProductionEra
  * assocControlledEventName
  * assocControlledEventType

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against core (updates to anthro inc shortly)