### PR TITLE
DRYD-1216: Add chronology vocabs

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -1965,7 +1965,9 @@
 		<title-ref>chronologytermtype</title-ref>
 		<title>Chronology Term Type</title>
 		<options>
-			<option id="placeholder">placeholder</option>
+			<option id="descriptor">descriptor</option>
+			<option id="alterate_descriptor">alternate descriptor</option>
+			<option id="used_for_term">used for term</option>
 		</options>
 	</instance>
 	<instance id="vocab-chronologytermflag">
@@ -1973,7 +1975,10 @@
 		<title-ref>chronologytermflag</title-ref>
 		<title>Chronology Term Flag</title>
 		<options>
-			<option id="placeholder">placeholder</option>
+			<option id="abbreviation">abbreviation</option>
+			<option id="common_term">common term</option>
+			<option id="full_term">full term</option>
+			<option id="jargon_slang">jargon/slang</option>
 		</options>
 	</instance>
 	<instance id="vocab-chronologytermstatus">
@@ -1981,7 +1986,10 @@
 		<title-ref>chronologytermstatus</title-ref>
 		<title>Chronology Term Status</title>
 		<options>
-			<option id="placeholder">placeholder</option>
+			<option id="provisional">provisional</option>
+			<option id="under_review">under review</option>
+			<option id="accepted">accepted</option>
+			<option id="rejected">rejected</option>
 		</options>
 	</instance>
 	<instance id="vocab-chronologyhistoricalstatus">
@@ -1989,7 +1997,9 @@
 		<title-ref>chronologyhistoricalstatus</title-ref>
 		<title>Chronology Historical Status</title>
 		<options>
-			<option id="placeholder">placeholder</option>
+			<option id="current">current</option>
+			<option id="historical">historical</option>
+			<option id="both">both</option>
 		</options>
 	</instance>
 	<instance id="vocab-chronologytypes">
@@ -1997,12 +2007,9 @@
 		<title-ref>chronologytypes</title-ref>
 		<title>Chronology Types</title>
 		<options>
-			<option id="archaeological_period">archaeological period</option>
-			<option id="dynasty">dynasty</option>
-			<option id="collection_activity">collection activity</option>
-			<option id="olympic_games">olympic games</option>
-			<option id="summer_games">summer games</option>
-			<option id="game_event">game event</option>
+			<option id="era">era</option>
+			<option id="historic">historic event</option>
+			<option id="field_collection">field collection event</option>
 		</options>
 	</instance>
 	<instance id="vocab-chronologypersonrelations">
@@ -2010,8 +2017,9 @@
 		<title-ref>chronologypersonrelations</title-ref>
 		<title>Chronology Person Relations</title>
 		<options>
-			<option id="monarch">monarch</option>
-			<option id="project_director">project director</option>
+			<option id="leader">leader</option>
+			<option id="participant">participant</option>
+			<option id="researcher">researcher</option>
 		</options>
 	</instance>
 	<instance id="vocab-chronologypeoplerelations">
@@ -2019,7 +2027,8 @@
 		<title-ref>chronologypeoplerelations</title-ref>
 		<title>Chronology People Relations</title>
 		<options>
-			<option id="placeholder">placeholder</option>
+			<option id="cultural_affiliation_museum">cultural affiliation by museum</option>
+			<option id="cultural_affiliation_tribe">cultural affiliation by tribe</option>
 		</options>
 	</instance>
 	<instance id="vocab-chronologyorganizationrelations">
@@ -2027,6 +2036,8 @@
 		<title-ref>chronologyorganizationrelations</title-ref>
 		<title>Chronology Organization Relations</title>
 		<options>
+			<option id="participant">participant</option>
+			<option id="researcher">researcher</option>
 			<option id="sponsor">sponsor</option>
 		</options>
 	</instance>
@@ -2035,7 +2046,7 @@
 		<title-ref>chronologyconceptrelations</title-ref>
 		<title>Chronology Concept Relations</title>
 		<options>
-			<option id="event_sport">event sport</option>
+			<option id="descriptor">descriptor</option>
 		</options>
 	</instance>
 	<instance id="vocab-chronologyplacerelations">
@@ -2043,11 +2054,8 @@
 		<title-ref>chronologyplacerelations</title-ref>
 		<title>Chronology Place Relations</title>
 		<options>
-			<option id="capital">capital</option>
-			<option id="modern_area">modern area</option>
-			<option id="main_location">main location</option>
-			<option id="additional_location">additional location</option>
-			<option id="venue">venue</option>
+			<option id="current_place">current place</option>
+			<option id="historic_place">historic place</option>
 		</options>
 	</instance>
 	<instance id="vocab-chronologyrelations">
@@ -2055,8 +2063,8 @@
 		<title-ref>chronologyrelations</title-ref>
 		<title>Chronology Relations</title>
 		<options>
-			<option id="follows">follows</option>
-			<option id="followed_by">followed by</option>
+			<option id="alternate">alternate description</option>
+			<option id="overlapping">overlapping term</option>
 		</options>
 	</instance>
 </instances>


### PR DESCRIPTION
**What does this do?**
Updates default chronology terms

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/jira/software/c/projects/DRYD/issues/DRYD-1216

The initial creation of the chronology authority was missing default terms. This sets the default terms from a curated list.

**How should this be tested? Do these changes have associated tests?**

* Rebuild collectionspace using this PR
* Check that the chronology vocabularies exist 

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter rebuilt and checked the new vocabs exist in core