### PR TITLE
DRYD-989: Fix incorrect XSD generation.

### DIFF
--- a/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/Record.java
+++ b/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/Record.java
@@ -387,7 +387,12 @@ public class Record implements FieldParent {
 		addSearchField(f);
 
 		if (parentType.equals("Record")) { //toplevel field
-			fieldTopLevel.put(f.getID(), f);
+			// DRYD-989: Index fields by schema:fieldname, so that identically named fields in different
+			// schema don't clobber each other. Technically this should be done in all the maps of
+			// fields in this class, but fieldTopLevel is the only one that is in use anymore, by the XSD
+			// generation process, since the app layer no longer does anything else. All the other dead
+			// code and unused maps should be removed at some point.
+			fieldTopLevel.put(f.getSection() + ":" + f.getID(), f);
 			if (f.isInServices() || f.isServicesDerived()) {
 				serviceFieldTopLevel.put(f.getID(), f);
 				//list fields by the operations they support


### PR DESCRIPTION
**What does this do?**

This fixes a bug in the generation of xsd (XML schema) files from the application config files. When the application config contains fields with the same name in multiple schema, those fields are omitted from some of the generated xsd files. The fields that should appear in multiple xsd files only appear in one.

This happens because when the application config files are parsed, fields are stored in a map keyed by name, and later retrieved from the map when generating the xsd files. When multiple fields in different schema have the same name, they overwrite each other in the map, since the key is only the local name, not a schema-qualified name. This is fixed by schema-qualifying the key in the map.

Note that the parsing code contains other similar maps, which are not used any more, since the application repo code no longer has the responsibilities it once did. This PR only modifies the one map that is in use for generating xsd files. The other code is dead, and will be removed in another PR.

**Why are we doing this? (with JIRA link)**

This resolves a bug in the public art profile, where the Publish To field failed to save. This happened because we added a Publish To field in the common schema with the same name, which caused the Publish To field in the publicart schema to disappear from the generated xsd files. Since it was no longer in the xsd files, Nuxeo became unaware of the field, and could not save it.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-989

**How should this be tested? Do these changes have associated tests?**

- Before applying the fix: Save the contents of $CSPACE_JEESERVER_HOME/nuxeo-server/tmp/schemas
- Apply the fix, and rebuild the application project
- In `services/services/JaxRsServiceProvider`, run `ant deploy_services_artifacts`
- Restart tomcat
- After tomcat has started: Compare the contents of $CSPACE_JEESERVER_HOME/nuxeo-server/tmp/schemas with the contents saved before the fix was applied. The file sizes should be identical, except for media_publicart.xsd, which should now be larger. Comparing media_publicart.xsd with its counterpart from before the fix, there should now be additional field definitions for `publishToList` and `publishTo`.

After applying the fix:
- In the public art profile, the Publish To field on media should now save. When the record is retrieved through the REST API, the value should appear in the `media_publicart/publishToList/publishTo` field.
- In all other profiles, the Publish To field on media should continue to save. When the record is retrieved through the REST API, the value should appear in the `media_common/publishToList/publishTo` field.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

No, this just fixes a bug.

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.