### PR TITLE
DRYD-1133: Add chronology to fcart and lhmc

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -2005,7 +2005,7 @@
 	<instance id="vocab-chronologytypes">
 		<web-url>chronologytypes</web-url>
 		<title-ref>chronologytypes</title-ref>
-		<title>Chronology Types</title>
+		<title>Chronology Authority Types</title>
 		<options>
 			<option id="era">era</option>
 			<option id="historic">historic event</option>

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -1415,4 +1415,111 @@
 			<option id="photocopying_not_allowed">Photocopying not allowed</option>
 		</options>
 	</instance>
+	<instance id="vocab-chronologytermtype">
+		<web-url>chronologytermtype</web-url>
+		<title-ref>chronologytermtype</title-ref>
+		<title>Chronology Term Type</title>
+		<options>
+			<option id="descriptor">descriptor</option>
+			<option id="alterate_descriptor">alternate descriptor</option>
+			<option id="used_for_term">used for term</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytermflag">
+		<web-url>chronologytermflag</web-url>
+		<title-ref>chronologytermflag</title-ref>
+		<title>Chronology Term Flag</title>
+		<options>
+			<option id="abbreviation">abbreviation</option>
+			<option id="common_term">common term</option>
+			<option id="full_term">full term</option>
+			<option id="jargon_slang">jargon/slang</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytermstatus">
+		<web-url>chronologytermstatus</web-url>
+		<title-ref>chronologytermstatus</title-ref>
+		<title>Chronology Term Status</title>
+		<options>
+			<option id="provisional">provisional</option>
+			<option id="under_review">under review</option>
+			<option id="accepted">accepted</option>
+			<option id="rejected">rejected</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyhistoricalstatus">
+		<web-url>chronologyhistoricalstatus</web-url>
+		<title-ref>chronologyhistoricalstatus</title-ref>
+		<title>Chronology Historical Status</title>
+		<options>
+			<option id="current">current</option>
+			<option id="historical">historical</option>
+			<option id="both">both</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytypes">
+		<web-url>chronologytypes</web-url>
+		<title-ref>chronologytypes</title-ref>
+		<title>Chronology Authority Types</title>
+		<options>
+			<option id="era">era</option>
+			<option id="historic">historic event</option>
+			<option id="field_collection">field collection event</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologypersonrelations">
+		<web-url>chronologypersonrelations</web-url>
+		<title-ref>chronologypersonrelations</title-ref>
+		<title>Chronology Person Relations</title>
+		<options>
+			<option id="leader">leader</option>
+			<option id="participant">participant</option>
+			<option id="researcher">researcher</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologypeoplerelations">
+		<web-url>chronologypeoplerelations</web-url>
+		<title-ref>chronologypeoplerelations</title-ref>
+		<title>Chronology People Relations</title>
+		<options>
+			<option id="cultural_affiliation_museum">cultural affiliation by museum</option>
+			<option id="cultural_affiliation_tribe">cultural affiliation by tribe</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyorganizationrelations">
+		<web-url>chronologyorganizationrelations</web-url>
+		<title-ref>chronologyorganizationrelations</title-ref>
+		<title>Chronology Organization Relations</title>
+		<options>
+			<option id="participant">participant</option>
+			<option id="researcher">researcher</option>
+			<option id="sponsor">sponsor</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyconceptrelations">
+		<web-url>chronologyconceptrelations</web-url>
+		<title-ref>chronologyconceptrelations</title-ref>
+		<title>Chronology Concept Relations</title>
+		<options>
+			<option id="descriptor">descriptor</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyplacerelations">
+		<web-url>chronologyplacerelations</web-url>
+		<title-ref>chronologyplacerelations</title-ref>
+		<title>Chronology Place Relations</title>
+		<options>
+			<option id="current_place">current place</option>
+			<option id="historic_place">historic place</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyrelations">
+		<web-url>chronologyrelations</web-url>
+		<title-ref>chronologyrelations</title-ref>
+		<title>Chronology Relations</title>
+		<options>
+			<option id="alternate">alternate description</option>
+			<option id="overlapping">overlapping term</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/fcart-tenant.xml
+++ b/tomcat-main/src/main/resources/fcart-tenant.xml
@@ -57,6 +57,8 @@
                     merge="xmlmerge.properties" />
 			<include src="base-authority-work-termList.xml" />
 			<include src="base-authority-work.xml" />
+			<include src="base-authority-chronology-termList.xml" />
+			<include src="base-authority-chronology.xml" />
 
 			<!-- <include src="extensions/fcart-profile-vocabularies.xml" /> -->
 			<include src="base-vocabularies.xml,extensions/fcart-profile-vocabularies.xml"

--- a/tomcat-main/src/main/resources/lhmc-tenant.xml
+++ b/tomcat-main/src/main/resources/lhmc-tenant.xml
@@ -49,6 +49,8 @@
 			<include src="base-authority-concept.xml" />
 			<include src="base-authority-work-termList.xml"/>
 			<include src="base-authority-work.xml"/>
+			<include src="base-authority-chronology-termList.xml" />
+			<include src="base-authority-chronology.xml" />
 
 			<include src="base-vocabularies.xml" />
 

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
@@ -1879,4 +1879,113 @@
 			<option id="notrestricted">not restricted</option>
 		</options>
 	</instance>
+	<!--
+	<instance id="vocab-chronologytermtype">
+		<web-url>chronologytermtype</web-url>
+		<title-ref>chronologytermtype</title-ref>
+		<title>Chronology Term Type</title>
+		<options>
+			<option id="descriptor">descriptor</option>
+			<option id="alterate_descriptor">alternate descriptor</option>
+			<option id="used_for_term">used for term</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytermflag">
+		<web-url>chronologytermflag</web-url>
+		<title-ref>chronologytermflag</title-ref>
+		<title>Chronology Term Flag</title>
+		<options>
+			<option id="abbreviation">abbreviation</option>
+			<option id="common_term">common term</option>
+			<option id="full_term">full term</option>
+			<option id="jargon_slang">jargon/slang</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytermstatus">
+		<web-url>chronologytermstatus</web-url>
+		<title-ref>chronologytermstatus</title-ref>
+		<title>Chronology Term Status</title>
+		<options>
+			<option id="provisional">provisional</option>
+			<option id="under_review">under review</option>
+			<option id="accepted">accepted</option>
+			<option id="rejected">rejected</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyhistoricalstatus">
+		<web-url>chronologyhistoricalstatus</web-url>
+		<title-ref>chronologyhistoricalstatus</title-ref>
+		<title>Chronology Historical Status</title>
+		<options>
+			<option id="current">current</option>
+			<option id="historical">historical</option>
+			<option id="both">both</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytypes">
+		<web-url>chronologytypes</web-url>
+		<title-ref>chronologytypes</title-ref>
+		<title>Chronology Authority Types</title>
+		<options>
+			<option id="era">era</option>
+			<option id="historic">historic event</option>
+			<option id="field_collection">field collection event</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologypersonrelations">
+		<web-url>chronologypersonrelations</web-url>
+		<title-ref>chronologypersonrelations</title-ref>
+		<title>Chronology Person Relations</title>
+		<options>
+			<option id="leader">leader</option>
+			<option id="participant">participant</option>
+			<option id="researcher">researcher</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologypeoplerelations">
+		<web-url>chronologypeoplerelations</web-url>
+		<title-ref>chronologypeoplerelations</title-ref>
+		<title>Chronology People Relations</title>
+		<options>
+			<option id="cultural_affiliation_museum">cultural affiliation by museum</option>
+			<option id="cultural_affiliation_tribe">cultural affiliation by tribe</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyorganizationrelations">
+		<web-url>chronologyorganizationrelations</web-url>
+		<title-ref>chronologyorganizationrelations</title-ref>
+		<title>Chronology Organization Relations</title>
+		<options>
+			<option id="participant">participant</option>
+			<option id="researcher">researcher</option>
+			<option id="sponsor">sponsor</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyconceptrelations">
+		<web-url>chronologyconceptrelations</web-url>
+		<title-ref>chronologyconceptrelations</title-ref>
+		<title>Chronology Concept Relations</title>
+		<options>
+			<option id="descriptor">descriptor</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyplacerelations">
+		<web-url>chronologyplacerelations</web-url>
+		<title-ref>chronologyplacerelations</title-ref>
+		<title>Chronology Place Relations</title>
+		<options>
+			<option id="current_place">current place</option>
+			<option id="historic_place">historic place</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyrelations">
+		<web-url>chronologyrelations</web-url>
+		<title-ref>chronologyrelations</title-ref>
+		<title>Chronology Relations</title>
+		<options>
+			<option id="alternate">alternate description</option>
+			<option id="overlapping">overlapping term</option>
+		</options>
+	</instance>
+	-->
 </instances>

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -1347,4 +1347,113 @@
 			<option id="MD5">MD5</option>
 		</options>
 	</instance>
+	<!--
+	<instance id="vocab-chronologytermtype">
+		<web-url>chronologytermtype</web-url>
+		<title-ref>chronologytermtype</title-ref>
+		<title>Chronology Term Type</title>
+		<options>
+			<option id="descriptor">descriptor</option>
+			<option id="alterate_descriptor">alternate descriptor</option>
+			<option id="used_for_term">used for term</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytermflag">
+		<web-url>chronologytermflag</web-url>
+		<title-ref>chronologytermflag</title-ref>
+		<title>Chronology Term Flag</title>
+		<options>
+			<option id="abbreviation">abbreviation</option>
+			<option id="common_term">common term</option>
+			<option id="full_term">full term</option>
+			<option id="jargon_slang">jargon/slang</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytermstatus">
+		<web-url>chronologytermstatus</web-url>
+		<title-ref>chronologytermstatus</title-ref>
+		<title>Chronology Term Status</title>
+		<options>
+			<option id="provisional">provisional</option>
+			<option id="under_review">under review</option>
+			<option id="accepted">accepted</option>
+			<option id="rejected">rejected</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyhistoricalstatus">
+		<web-url>chronologyhistoricalstatus</web-url>
+		<title-ref>chronologyhistoricalstatus</title-ref>
+		<title>Chronology Historical Status</title>
+		<options>
+			<option id="current">current</option>
+			<option id="historical">historical</option>
+			<option id="both">both</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytypes">
+		<web-url>chronologytypes</web-url>
+		<title-ref>chronologytypes</title-ref>
+		<title>Chronology Authority Types</title>
+		<options>
+			<option id="era">era</option>
+			<option id="historic">historic event</option>
+			<option id="field_collection">field collection event</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologypersonrelations">
+		<web-url>chronologypersonrelations</web-url>
+		<title-ref>chronologypersonrelations</title-ref>
+		<title>Chronology Person Relations</title>
+		<options>
+			<option id="leader">leader</option>
+			<option id="participant">participant</option>
+			<option id="researcher">researcher</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologypeoplerelations">
+		<web-url>chronologypeoplerelations</web-url>
+		<title-ref>chronologypeoplerelations</title-ref>
+		<title>Chronology People Relations</title>
+		<options>
+			<option id="cultural_affiliation_museum">cultural affiliation by museum</option>
+			<option id="cultural_affiliation_tribe">cultural affiliation by tribe</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyorganizationrelations">
+		<web-url>chronologyorganizationrelations</web-url>
+		<title-ref>chronologyorganizationrelations</title-ref>
+		<title>Chronology Organization Relations</title>
+		<options>
+			<option id="participant">participant</option>
+			<option id="researcher">researcher</option>
+			<option id="sponsor">sponsor</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyconceptrelations">
+		<web-url>chronologyconceptrelations</web-url>
+		<title-ref>chronologyconceptrelations</title-ref>
+		<title>Chronology Concept Relations</title>
+		<options>
+			<option id="descriptor">descriptor</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyplacerelations">
+		<web-url>chronologyplacerelations</web-url>
+		<title-ref>chronologyplacerelations</title-ref>
+		<title>Chronology Place Relations</title>
+		<options>
+			<option id="current_place">current place</option>
+			<option id="historic_place">historic place</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyrelations">
+		<web-url>chronologyrelations</web-url>
+		<title-ref>chronologyrelations</title-ref>
+		<title>Chronology Relations</title>
+		<options>
+			<option id="alternate">alternate description</option>
+			<option id="overlapping">overlapping term</option>
+		</options>
+	</instance>
+	-->
 </instances>

--- a/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
@@ -1930,4 +1930,113 @@
 			<option id="photocopying_not_allowed">Photocopying not allowed</option>
 		</options>
 	</instance>
+	<!--
+	<instance id="vocab-chronologytermtype">
+		<web-url>chronologytermtype</web-url>
+		<title-ref>chronologytermtype</title-ref>
+		<title>Chronology Term Type</title>
+		<options>
+			<option id="descriptor">descriptor</option>
+			<option id="alterate_descriptor">alternate descriptor</option>
+			<option id="used_for_term">used for term</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytermflag">
+		<web-url>chronologytermflag</web-url>
+		<title-ref>chronologytermflag</title-ref>
+		<title>Chronology Term Flag</title>
+		<options>
+			<option id="abbreviation">abbreviation</option>
+			<option id="common_term">common term</option>
+			<option id="full_term">full term</option>
+			<option id="jargon_slang">jargon/slang</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytermstatus">
+		<web-url>chronologytermstatus</web-url>
+		<title-ref>chronologytermstatus</title-ref>
+		<title>Chronology Term Status</title>
+		<options>
+			<option id="provisional">provisional</option>
+			<option id="under_review">under review</option>
+			<option id="accepted">accepted</option>
+			<option id="rejected">rejected</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyhistoricalstatus">
+		<web-url>chronologyhistoricalstatus</web-url>
+		<title-ref>chronologyhistoricalstatus</title-ref>
+		<title>Chronology Historical Status</title>
+		<options>
+			<option id="current">current</option>
+			<option id="historical">historical</option>
+			<option id="both">both</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologytypes">
+		<web-url>chronologytypes</web-url>
+		<title-ref>chronologytypes</title-ref>
+		<title>Chronology Authority Types</title>
+		<options>
+			<option id="era">era</option>
+			<option id="historic">historic event</option>
+			<option id="field_collection">field collection event</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologypersonrelations">
+		<web-url>chronologypersonrelations</web-url>
+		<title-ref>chronologypersonrelations</title-ref>
+		<title>Chronology Person Relations</title>
+		<options>
+			<option id="leader">leader</option>
+			<option id="participant">participant</option>
+			<option id="researcher">researcher</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologypeoplerelations">
+		<web-url>chronologypeoplerelations</web-url>
+		<title-ref>chronologypeoplerelations</title-ref>
+		<title>Chronology People Relations</title>
+		<options>
+			<option id="cultural_affiliation_museum">cultural affiliation by museum</option>
+			<option id="cultural_affiliation_tribe">cultural affiliation by tribe</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyorganizationrelations">
+		<web-url>chronologyorganizationrelations</web-url>
+		<title-ref>chronologyorganizationrelations</title-ref>
+		<title>Chronology Organization Relations</title>
+		<options>
+			<option id="participant">participant</option>
+			<option id="researcher">researcher</option>
+			<option id="sponsor">sponsor</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyconceptrelations">
+		<web-url>chronologyconceptrelations</web-url>
+		<title-ref>chronologyconceptrelations</title-ref>
+		<title>Chronology Concept Relations</title>
+		<options>
+			<option id="descriptor">descriptor</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyplacerelations">
+		<web-url>chronologyplacerelations</web-url>
+		<title-ref>chronologyplacerelations</title-ref>
+		<title>Chronology Place Relations</title>
+		<options>
+			<option id="current_place">current place</option>
+			<option id="historic_place">historic place</option>
+		</options>
+	</instance>
+	<instance id="vocab-chronologyrelations">
+		<web-url>chronologyrelations</web-url>
+		<title-ref>chronologyrelations</title-ref>
+		<title>Chronology Relations</title>
+		<options>
+			<option id="alternate">alternate description</option>
+			<option id="overlapping">overlapping term</option>
+		</options>
+	</instance>
+	-->
 </instances>


### PR DESCRIPTION
**What does this do?**
* Adds chronology to fcart and lhmc tenants
* Syncs chronology vocabs with all tenants 

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1133

Requested in most recent comment to enable chronology for fcart and lhmc

**How should this be tested? Do these changes have associated tests?**
* Build collectionspace with core, fcart, lhmc, and anthro profiles enabled
* Run collectionspace and test the chronology vocabs exist and the authority can be created

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against fcart and lhmc