### PR TITLE
Controlled Events and fcart Nomenclature

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -259,6 +259,9 @@
 				<field id="contentEventName" />
 				<field id="contentEventNameType" />
 			</repeat>
+			<repeat id="contentEvents">
+				<field id="contentEvent" autocomplete="true" />
+			</repeat>
 			<repeat id="contentOtherGroupList/contentOtherGroup">
 				<field id="contentOther" />
 				<field id="contentOtherType" />

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -404,7 +404,6 @@
 			<field id="assocEventNameType" />
 
 			<field id="assocEvent" autocomplete="true" />
-			<field id="assocEventType" />
 
 			<repeat id="assocEventOrganizations">
 				<field id="assocEventOrganization" autocomplete="true" />

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -403,7 +403,9 @@
 			<field id="assocEventName" />
 			<field id="assocEventNameType" />
 
-			<field id="assocEvent" autocomplete="true" />
+			<repeat id="assocEvents">
+				<field id="assocEvent" autocomplete="true" />
+			</repeat>
 
 			<repeat id="assocEventOrganizations">
 				<field id="assocEventOrganization" autocomplete="true" />

--- a/tomcat-main/src/main/resources/defaults/extensions/fineart-authority-concept.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fineart-authority-concept.xml
@@ -25,6 +25,11 @@
 			<title-ref>ethculture</title-ref>
 			<title>Ethnographic Cultures</title>
 		</instance>
+		<instance id="concept-nomenclature">
+			<web-url>nomenclature</web-url>
+			<title-ref>nomenclature</title-ref>
+			<title>Nomenclature</title>
+		</instance>
 	</instances>
 
 	<section id="conceptAuthorityInformation">

--- a/tomcat-main/src/main/resources/tenants/anthro/anthro-collectionobject.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/anthro-collectionobject.xml
@@ -5,7 +5,8 @@
 		<repeat id="objectNameList/objectNameGroup">
 			<!-- Add mini -->
 			<field id="objectName" mini="list" />
-			<field id="objectNameControlled" mini="list" autocomplete="true" />
+			<!-- Add mini -->
+			<field id="objectNameControlled" mini="list" />
 		</repeat>
 
 		<!-- Local fields -->

--- a/tomcat-main/src/main/resources/tenants/anthro/anthro-collectionobject.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/anthro-collectionobject.xml
@@ -5,6 +5,7 @@
 		<repeat id="objectNameList/objectNameGroup">
 			<!-- Add mini -->
 			<field id="objectName" mini="list" />
+			<field id="objectNameControlled" mini="list" autocomplete="true" />
 		</repeat>
 
 		<!-- Local fields -->


### PR DESCRIPTION
**What does this do?**
* Adds controlled contentEvent to collectionobject
* Make assocEvent repeatable
* Remove assocEventType
* Add nomenclature concept to fcart

**Why are we doing this? (with JIRA link)**
Changes were requested for the assocEvent field to make it repeating and have the assocEventType removed. Along with this contentEvent was requested to be added. 

Nomenclature is being added to the fineart concepts as it is needed in order to be used by the controlled object name field.

Controlled event jira: https://collectionspace.atlassian.net/browse/DRYD-1238
Controlled obj name jira: https://collectionspace.atlassian.net/browse/DRYD-1128

**How should this be tested? Do these changes have associated tests?**
Testing mostly done in the cspace-ui projects, but the vocabulary can be done by building with the fcart profile enabled and curling:
```
curl --user admin@fcart.collectionspace.org:Administrator "http://localhost:8180/cspace-services/conceptauthorities/urn:cspace:name(nomenclature)"
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested changes locally 