### PR TITLE
7.2 QA Updates

### DIFF
--- a/tomcat-main/src/main/resources/anthro-tenant.xml
+++ b/tomcat-main/src/main/resources/anthro-tenant.xml
@@ -54,7 +54,7 @@
 			<include src="base-authority-work-termList.xml" />
 			<include src="base-authority-work.xml" />
 			<include src="base-authority-chronology-termList.xml" />
-			<include src="base-authority-chronology.xml" />
+			<include src="base-authority-chronology.xml,anthro-authority-chronology.xml" merge="xmlmerge.properties" />
 
 			<include src="base-vocabularies.xml" />
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
@@ -52,9 +52,9 @@
   <section id="chronologyInformation">
     <field id="preferredChronology" ui-type="groupfield/preferredChronology/selfrenderer" />
 
-    <field id="chronologyDateStructuredDateGroup" ui-type="groupfield/structureddate" />
-    <repeat id="chronologyPlaces">
-      <field id="chronologyPlace" autocomplete="true" />
+    <field id="primaryDateRangeStructuredDateGroup" ui-type="groupfield/structureddate" />
+    <repeat id="spatialCoverages">
+      <field id="spatialCoverage" autocomplete="true" />
     </repeat>
     <field id="chronologyType" autocomplete="true" ui-type="enum" />
     <field id="chronologyNote" />
@@ -66,15 +66,15 @@
       <field id="identifierDate" />
     </repeat>
 
-    <repeat id="otherDateGroupList/otherDateGroup">
-      <field id="otherDateStructuredDateGroup" ui-type="groupfield/structureddate" />
-      <repeat id="otherDatePlaces">
-        <field id="otherDatePlace" autocomplete="true" />
+    <repeat id="altDateGroupList/altDateGroup">
+      <field id="altDateRangeStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="altDateSpatialCoverages">
+        <field id="altDateSpatialCoverage" autocomplete="true" />
       </repeat>
-      <repeat id="otherDateCitations">
-        <field id="otherDateCitation" autocomplete="true" />
+      <repeat id="altDateCitations">
+        <field id="altDateCitation" autocomplete="true" />
       </repeat>
-      <field id="otherDateNote" />
+      <field id="altDateNote" />
     </repeat>
 
     <repeat id="personGroupList/personGroup">

--- a/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
@@ -38,11 +38,6 @@
       <title-ref>event</title-ref>
       <title>Event Chronologies</title>
     </instance>
-    <instance id="chronology-field_collection">
-      <web-url>field_collection</web-url>
-      <title-ref>field_collection</title-ref>
-      <title>Field Collection Chronologies</title>
-    </instance>
   </instances>
 
   <section id="coreInformation">

--- a/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
@@ -76,66 +76,6 @@
       </repeat>
       <field id="altDateNote" />
     </repeat>
-
-    <repeat id="personGroupList/personGroup">
-      <field id="person" autocomplete="true" />
-      <field id="personType" autocomplete="true" ui-type="enum" />
-      <field id="personStructuredDateGroup" ui-type="groupfield/structureddate" />
-      <repeat id="personCitations">
-        <field id="personCitation" autocomplete="true" />
-      </repeat>
-      <field id="personNote" />
-    </repeat>
-
-    <repeat id="peopleGroupList/peopleGroup">
-      <field id="people" autocomplete="true" />
-      <field id="peopleType" autocomplete="true" ui-type="enum" />
-      <field id="peopleStructuredDateGroup" ui-type="groupfield/structureddate" />
-      <repeat id="peopleCitations">
-        <field id="peopleCitation" autocomplete="true" />
-      </repeat>
-      <field id="peopleNote" />
-    </repeat>
-
-    <repeat id="organizationGroupList/organizationGroup">
-      <field id="organization" autocomplete="true" />
-      <field id="organizationType" autocomplete="true" ui-type="enum" />
-      <field id="organizationStructuredDateGroup" ui-type="groupfield/structureddate" />
-      <repeat id="organizationCitations">
-        <field id="organizationCitation" autocomplete="true" />
-      </repeat>
-      <field id="organizationNote" />
-    </repeat>
-
-    <repeat id="conceptGroupList/conceptGroup">
-      <field id="concept" autocomplete="true" />
-      <field id="conceptType" autocomplete="true" ui-type="enum" />
-      <field id="conceptStructuredDateGroup" ui-type="groupfield/structureddate" />
-      <repeat id="conceptCitations">
-        <field id="conceptCitation" autocomplete="true" />
-      </repeat>
-      <field id="conceptNote" />
-    </repeat>
-
-    <repeat id="placeGroupList/placeGroup">
-      <field id="place" autocomplete="true" />
-      <field id="placeType" autocomplete="true" ui-type="enum" />
-      <field id="placeStructuredDateGroup" ui-type="groupfield/structureddate" />
-      <repeat id="placeCitations">
-        <field id="placeCitation" autocomplete="true" />
-      </repeat>
-      <field id="placeNote" />
-    </repeat>
-
-    <repeat id="relatedPeriodGroupList/relatedPeriodGroup">
-      <field id="relatedPeriod" autocomplete="true" />
-      <field id="relatedPeriodType" autocomplete="true" ui-type="enum" />
-      <field id="relatedPeriodStructuredDateGroup" ui-type="groupfield/structureddate" />
-      <repeat id="relatedPeriodCitations">
-        <field id="relatedPeriodCitation" autocomplete="true" />
-      </repeat>
-      <field id="relatedPeriodNote" />
-    </repeat>
   </section>
 
   <!-- not used in UI except in autocompletes -->

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -2012,61 +2012,6 @@
 			<option id="field_collection">field collection event</option>
 		</options>
 	</instance>
-	<instance id="vocab-chronologypersonrelations">
-		<web-url>chronologypersonrelations</web-url>
-		<title-ref>chronologypersonrelations</title-ref>
-		<title>Chronology Person Relations</title>
-		<options>
-			<option id="leader">leader</option>
-			<option id="participant">participant</option>
-			<option id="researcher">researcher</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologypeoplerelations">
-		<web-url>chronologypeoplerelations</web-url>
-		<title-ref>chronologypeoplerelations</title-ref>
-		<title>Chronology People Relations</title>
-		<options>
-			<option id="cultural_affiliation_museum">cultural affiliation by museum</option>
-			<option id="cultural_affiliation_tribe">cultural affiliation by tribe</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyorganizationrelations">
-		<web-url>chronologyorganizationrelations</web-url>
-		<title-ref>chronologyorganizationrelations</title-ref>
-		<title>Chronology Organization Relations</title>
-		<options>
-			<option id="participant">participant</option>
-			<option id="researcher">researcher</option>
-			<option id="sponsor">sponsor</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyconceptrelations">
-		<web-url>chronologyconceptrelations</web-url>
-		<title-ref>chronologyconceptrelations</title-ref>
-		<title>Chronology Concept Relations</title>
-		<options>
-			<option id="descriptor">descriptor</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyplacerelations">
-		<web-url>chronologyplacerelations</web-url>
-		<title-ref>chronologyplacerelations</title-ref>
-		<title>Chronology Place Relations</title>
-		<options>
-			<option id="current_place">current place</option>
-			<option id="historic_place">historic place</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyrelations">
-		<web-url>chronologyrelations</web-url>
-		<title-ref>chronologyrelations</title-ref>
-		<title>Chronology Relations</title>
-		<options>
-			<option id="alternate">alternate description</option>
-			<option id="overlapping">overlapping term</option>
-		</options>
-	</instance>
 	<instance id="vocab-apparelsizes">
 		<web-url>apparelsizes</web-url>
 		<title-ref>apparelsizes</title-ref>

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -1467,61 +1467,6 @@
 			<option id="field_collection">field collection event</option>
 		</options>
 	</instance>
-	<instance id="vocab-chronologypersonrelations">
-		<web-url>chronologypersonrelations</web-url>
-		<title-ref>chronologypersonrelations</title-ref>
-		<title>Chronology Person Relations</title>
-		<options>
-			<option id="leader">leader</option>
-			<option id="participant">participant</option>
-			<option id="researcher">researcher</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologypeoplerelations">
-		<web-url>chronologypeoplerelations</web-url>
-		<title-ref>chronologypeoplerelations</title-ref>
-		<title>Chronology People Relations</title>
-		<options>
-			<option id="cultural_affiliation_museum">cultural affiliation by museum</option>
-			<option id="cultural_affiliation_tribe">cultural affiliation by tribe</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyorganizationrelations">
-		<web-url>chronologyorganizationrelations</web-url>
-		<title-ref>chronologyorganizationrelations</title-ref>
-		<title>Chronology Organization Relations</title>
-		<options>
-			<option id="participant">participant</option>
-			<option id="researcher">researcher</option>
-			<option id="sponsor">sponsor</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyconceptrelations">
-		<web-url>chronologyconceptrelations</web-url>
-		<title-ref>chronologyconceptrelations</title-ref>
-		<title>Chronology Concept Relations</title>
-		<options>
-			<option id="descriptor">descriptor</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyplacerelations">
-		<web-url>chronologyplacerelations</web-url>
-		<title-ref>chronologyplacerelations</title-ref>
-		<title>Chronology Place Relations</title>
-		<options>
-			<option id="current_place">current place</option>
-			<option id="historic_place">historic place</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyrelations">
-		<web-url>chronologyrelations</web-url>
-		<title-ref>chronologyrelations</title-ref>
-		<title>Chronology Relations</title>
-		<options>
-			<option id="alternate">alternate description</option>
-			<option id="overlapping">overlapping term</option>
-		</options>
-	</instance>
 	<instance id="vocab-descriptionlevel">
 		<web-url>descriptionlevel</web-url>
 		<title-ref>descriptionlevel</title-ref>

--- a/tomcat-main/src/main/resources/tenants/anthro/anthro-authority-chronology.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/anthro-authority-chronology.xml
@@ -1,0 +1,19 @@
+<record id="chronology" type="authority">
+  <instances id="chronology">
+    <instance id="chronology-era">
+      <web-url>era</web-url>
+      <title-ref>era</title-ref>
+      <title>Era Chronologies</title>
+    </instance>
+    <instance id="chronology-event">
+      <web-url>event</web-url>
+      <title-ref>event</title-ref>
+      <title>Event Chronologies</title>
+    </instance>
+    <instance id="chronology-field_collection">
+      <web-url>field_collection</web-url>
+      <title-ref>field_collection</title-ref>
+      <title>Field Collection Chronologies</title>
+    </instance>
+  </instances>
+</record>


### PR DESCRIPTION
**What does this do?**
* Updates to chronology field names so that they're consistent with the ui names
* Move the chronology fieldcollection authority to anthro
* Remove the associated authority block so that it can be re-spec'd

**Why are we doing this? (with JIRA link)**
* https://collectionspace.atlassian.net/browse/DRYD-1261
* https://collectionspace.atlassian.net/browse/DRYD-1264
* https://collectionspace.atlassian.net/browse/DRYD-1267

This brings in a few changes from QA which were identified as bringing more consistency to the chronology authority as well as tenant deployments. In addition, the associated authorities block was seen as still needing more work before it's ready for production and as such has been removed from the chronology authority as well as having its vocabularies removed. 

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Verify that the chronology fieldcollection authority is not available in core
* Verify that the associated authorities do not display on chronology records
* Verify that the chronology field names are updated
  * `primaryDateRangeStructuredDateGroup`
  * `spatialCoverages` + subfields
  * `altDateGroupList` + subfields

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance