### PR TITLE
DRYD-1286: Create associated authorities fields

### DIFF
--- a/tomcat-main/src/main/resources/anthro-tenant.xml
+++ b/tomcat-main/src/main/resources/anthro-tenant.xml
@@ -80,6 +80,7 @@
 			<include src="base-other-batchoutput.xml" />
 			<include src="base-other-invocationresults.xml" />
 			<include src="base-other-searchall.xml" />
+			<include src="base-other-associatedauthority.xml" />
 		</records>
 	</spec>
 </cspace-config>

--- a/tomcat-main/src/main/resources/bonsai-tenant.xml
+++ b/tomcat-main/src/main/resources/bonsai-tenant.xml
@@ -76,6 +76,7 @@
       <include src="base-other-batchoutput.xml" />
       <include src="base-other-invocationresults.xml" />
       <include src="base-other-searchall.xml" />
+			<include src="base-other-associatedauthority.xml" />
     </records>
   </spec>
 </cspace-config>

--- a/tomcat-main/src/main/resources/botgarden-tenant.xml
+++ b/tomcat-main/src/main/resources/botgarden-tenant.xml
@@ -71,6 +71,7 @@
 			<include src="base-other-batchoutput.xml" />
 			<include src="base-other-invocationresults.xml" />
 			<include src="base-other-searchall.xml" />
+			<include src="base-other-associatedauthority.xml" />
 		</records>
 	</spec>
 </cspace-config>

--- a/tomcat-main/src/main/resources/core-tenant.xml
+++ b/tomcat-main/src/main/resources/core-tenant.xml
@@ -31,7 +31,7 @@
 			<include src="base-procedure-objectexit.xml" />
 			<include src="base-procedure-conservation.xml" />
 			<include src="base-procedure-uoc.xml" />
-                        <include src="base-procedure-transport.xml" />
+			<include src="base-procedure-transport.xml" />
 
 			<include src="base-authority-contact.xml" />
                         <!-- IMPORTANT: *-termList.xml files MUST precede their equivalent files. -->
@@ -76,10 +76,11 @@
 			<include src="base-other-termlistitem.xml" />
 			<include src="base-other-reporting.xml" />
 			<include src="base-other-reportingoutput.xml" />
-		    <include src="base-other-batch.xml" />
-		    <include src="base-other-batchoutput.xml" />
-		    <include src="base-other-invocationresults.xml" />
+			<include src="base-other-batch.xml" />
+			<include src="base-other-batchoutput.xml" />
+			<include src="base-other-invocationresults.xml" />
 			<include src="base-other-searchall.xml" />
+			<include src="base-other-associatedauthority.xml" />
 		</records>
 	</spec>
 </cspace-config>

--- a/tomcat-main/src/main/resources/default.xml
+++ b/tomcat-main/src/main/resources/default.xml
@@ -74,6 +74,7 @@
       <include src="base-other-batchoutput.xml" />
       <include src="base-other-invocationresults.xml" />
       <include src="base-other-searchall.xml" />
+      <include src="base-other-associatedauthority.xml" />
     </records>
   </spec>
 </cspace-config>

--- a/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
@@ -73,6 +73,10 @@
     </repeat>
   </section>
 
+  <section id="associationInformation">
+    <include src="base-other-associatedauthority.xml" strip-root="true" />
+  </section>
+
   <!-- not used in UI except in autocompletes -->
   <section id="otherInformation">
     <field id="inAuthority" services-should-index="true" />

--- a/tomcat-main/src/main/resources/defaults/base-authority-person.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-person.xml
@@ -129,6 +129,10 @@
 		</repeat>
 	</section>
 
+	<section id="associationInformation">
+		<include src="base-other-associatedauthority.xml" strip-root="true" />
+	</section>
+
 	<!-- not used in UI except in autocompletes -->
 	<section id="otherInformation">
 		<field id="inAuthority" services-should-index="true" />

--- a/tomcat-main/src/main/resources/defaults/base-authority-place.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-place.xml
@@ -130,6 +130,10 @@
 		</repeat>
 	</section>
 
+	<section id="associationInformation">
+		<include src="base-other-associatedauthority.xml" strip-root="true" />
+	</section>
+
 	<!-- not used in UI except in autocompletes -->
 	<section id="otherInformation">
 		<field id="inAuthority" services-should-index="true" />

--- a/tomcat-main/src/main/resources/defaults/base-other-associatedauthority.xml
+++ b/tomcat-main/src/main/resources/defaults/base-other-associatedauthority.xml
@@ -1,0 +1,63 @@
+<record id="associatedauthority" in-recordlist="no" separate-record="false" services-type="associatedAuthorities">
+  <section id="associationInformation">
+    <repeat id="assocPersonAuthGroupList/assocPersonAuthGroup">
+      <field id="person" autocomplete="true" />
+      <field id="personType" autocomplete="true" ui-type="enum" />
+      <field id="personStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="personCitations">
+        <field id="personCitation" autocomplete="true" />
+      </repeat>
+      <field id="personNote" />
+    </repeat>
+
+    <repeat id="assocPeopleAuthGroupList/assocPeopleAuthGroup">
+      <field id="people" autocomplete="true" />
+      <field id="peopleType" autocomplete="true" ui-type="enum" />
+      <field id="peopleStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="peopleCitations">
+        <field id="peopleCitation" autocomplete="true" />
+      </repeat>
+      <field id="peopleNote" />
+    </repeat>
+
+    <repeat id="assocOrganizationAuthGroupList/assocOrganizationAuthGroup">
+      <field id="organization" autocomplete="true" />
+      <field id="organizationType" autocomplete="true" ui-type="enum" />
+      <field id="organizationStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="organizationCitations">
+        <field id="organizationCitation" autocomplete="true" />
+      </repeat>
+      <field id="organizationNote" />
+    </repeat>
+
+    <repeat id="assocConceptAuthGroupList/assocConceptAuthGroup">
+      <field id="concept" autocomplete="true" />
+      <field id="conceptType" autocomplete="true" ui-type="enum" />
+      <field id="conceptStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="conceptCitations">
+        <field id="conceptCitation" autocomplete="true" />
+      </repeat>
+      <field id="conceptNote" />
+    </repeat>
+
+    <repeat id="assocPlaceAuthGroupList/assocPlaceAuthGroup">
+      <field id="place" autocomplete="true" />
+      <field id="placeType" autocomplete="true" ui-type="enum" />
+      <field id="placeStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="placeCitations">
+        <field id="placeCitation" autocomplete="true" />
+      </repeat>
+      <field id="placeNote" />
+    </repeat>
+
+    <repeat id="assocChronologyAuthGroupList/assocChronologyAuthGroup">
+      <field id="chronology" autocomplete="true" />
+      <field id="chronologyType" autocomplete="true" ui-type="enum" />
+      <field id="chronologyStructuredDateGroup" ui-type="groupfield/structureddate" />
+      <repeat id="chronologyCitations">
+        <field id="chronologyCitation" autocomplete="true" />
+      </repeat>
+      <field id="chronologyNote" />
+    </repeat>
+  </section>
+</record>

--- a/tomcat-main/src/main/resources/fcart-tenant.xml
+++ b/tomcat-main/src/main/resources/fcart-tenant.xml
@@ -82,10 +82,11 @@
 			<include src="base-other-termlistitem.xml" />
 			<include src="base-other-reporting.xml" />
 			<include src="base-other-reportingoutput.xml" />
-		    <include src="base-other-batch.xml" />
-		    <include src="base-other-batchoutput.xml" />
-		    <include src="base-other-invocationresults.xml" />
-		    <include src="base-other-searchall.xml" />
+			<include src="base-other-batch.xml" />
+			<include src="base-other-batchoutput.xml" />
+			<include src="base-other-invocationresults.xml" />
+			<include src="base-other-searchall.xml" />
+			<include src="base-other-associatedauthority.xml" />
 		</records>
 	</spec>
 </cspace-config>

--- a/tomcat-main/src/main/resources/herbarium-tenant.xml
+++ b/tomcat-main/src/main/resources/herbarium-tenant.xml
@@ -69,6 +69,7 @@
 		    <include src="base-other-batchoutput.xml" />
 		    <include src="base-other-invocationresults.xml" />
 		    <include src="base-other-searchall.xml" />
+			<include src="base-other-associatedauthority.xml" />
 		</records>
 	</spec>
 </cspace-config>

--- a/tomcat-main/src/main/resources/lhmc-tenant.xml
+++ b/tomcat-main/src/main/resources/lhmc-tenant.xml
@@ -75,6 +75,7 @@
 			<include src="base-other-batchoutput.xml" />
 			<include src="base-other-invocationresults.xml" />
 			<include src="base-other-searchall.xml" />
+			<include src="base-other-associatedauthority.xml" />
 		</records>
 	</spec>
 </cspace-config>

--- a/tomcat-main/src/main/resources/materials-tenant.xml
+++ b/tomcat-main/src/main/resources/materials-tenant.xml
@@ -84,6 +84,7 @@
 		    <include src="base-other-batchoutput.xml" />
 		    <include src="base-other-invocationresults.xml" />
 		    <include src="base-other-searchall.xml" />
+			<include src="base-other-associatedauthority.xml" />
 		</records>
 	</spec>
 </cspace-config>

--- a/tomcat-main/src/main/resources/publicart-tenant.xml
+++ b/tomcat-main/src/main/resources/publicart-tenant.xml
@@ -68,6 +68,7 @@
 		    <include src="base-other-batchoutput.xml" />
 		    <include src="base-other-invocationresults.xml" />
 		    <include src="base-other-searchall.xml" />
+			<include src="base-other-associatedauthority.xml" />
 		</records>
 	</spec>
 </cspace-config>

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
@@ -1932,61 +1932,6 @@
 			<option id="field_collection">field collection event</option>
 		</options>
 	</instance>
-	<instance id="vocab-chronologypersonrelations">
-		<web-url>chronologypersonrelations</web-url>
-		<title-ref>chronologypersonrelations</title-ref>
-		<title>Chronology Person Relations</title>
-		<options>
-			<option id="leader">leader</option>
-			<option id="participant">participant</option>
-			<option id="researcher">researcher</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologypeoplerelations">
-		<web-url>chronologypeoplerelations</web-url>
-		<title-ref>chronologypeoplerelations</title-ref>
-		<title>Chronology People Relations</title>
-		<options>
-			<option id="cultural_affiliation_museum">cultural affiliation by museum</option>
-			<option id="cultural_affiliation_tribe">cultural affiliation by tribe</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyorganizationrelations">
-		<web-url>chronologyorganizationrelations</web-url>
-		<title-ref>chronologyorganizationrelations</title-ref>
-		<title>Chronology Organization Relations</title>
-		<options>
-			<option id="participant">participant</option>
-			<option id="researcher">researcher</option>
-			<option id="sponsor">sponsor</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyconceptrelations">
-		<web-url>chronologyconceptrelations</web-url>
-		<title-ref>chronologyconceptrelations</title-ref>
-		<title>Chronology Concept Relations</title>
-		<options>
-			<option id="descriptor">descriptor</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyplacerelations">
-		<web-url>chronologyplacerelations</web-url>
-		<title-ref>chronologyplacerelations</title-ref>
-		<title>Chronology Place Relations</title>
-		<options>
-			<option id="current_place">current place</option>
-			<option id="historic_place">historic place</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyrelations">
-		<web-url>chronologyrelations</web-url>
-		<title-ref>chronologyrelations</title-ref>
-		<title>Chronology Relations</title>
-		<options>
-			<option id="alternate">alternate description</option>
-			<option id="overlapping">overlapping term</option>
-		</options>
-	</instance>
 	<instance id="vocab-apparelsizes">
 		<web-url>apparelsizes</web-url>
 		<title-ref>apparelsizes</title-ref>

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -1400,61 +1400,6 @@
 			<option id="field_collection">field collection event</option>
 		</options>
 	</instance>
-	<instance id="vocab-chronologypersonrelations">
-		<web-url>chronologypersonrelations</web-url>
-		<title-ref>chronologypersonrelations</title-ref>
-		<title>Chronology Person Relations</title>
-		<options>
-			<option id="leader">leader</option>
-			<option id="participant">participant</option>
-			<option id="researcher">researcher</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologypeoplerelations">
-		<web-url>chronologypeoplerelations</web-url>
-		<title-ref>chronologypeoplerelations</title-ref>
-		<title>Chronology People Relations</title>
-		<options>
-			<option id="cultural_affiliation_museum">cultural affiliation by museum</option>
-			<option id="cultural_affiliation_tribe">cultural affiliation by tribe</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyorganizationrelations">
-		<web-url>chronologyorganizationrelations</web-url>
-		<title-ref>chronologyorganizationrelations</title-ref>
-		<title>Chronology Organization Relations</title>
-		<options>
-			<option id="participant">participant</option>
-			<option id="researcher">researcher</option>
-			<option id="sponsor">sponsor</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyconceptrelations">
-		<web-url>chronologyconceptrelations</web-url>
-		<title-ref>chronologyconceptrelations</title-ref>
-		<title>Chronology Concept Relations</title>
-		<options>
-			<option id="descriptor">descriptor</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyplacerelations">
-		<web-url>chronologyplacerelations</web-url>
-		<title-ref>chronologyplacerelations</title-ref>
-		<title>Chronology Place Relations</title>
-		<options>
-			<option id="current_place">current place</option>
-			<option id="historic_place">historic place</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyrelations">
-		<web-url>chronologyrelations</web-url>
-		<title-ref>chronologyrelations</title-ref>
-		<title>Chronology Relations</title>
-		<options>
-			<option id="alternate">alternate description</option>
-			<option id="overlapping">overlapping term</option>
-		</options>
-	</instance>
 	<instance id="vocab-apparelsizes">
 		<web-url>apparelsizes</web-url>
 		<title-ref>apparelsizes</title-ref>

--- a/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
@@ -1983,61 +1983,6 @@
 			<option id="field_collection">field collection event</option>
 		</options>
 	</instance>
-	<instance id="vocab-chronologypersonrelations">
-		<web-url>chronologypersonrelations</web-url>
-		<title-ref>chronologypersonrelations</title-ref>
-		<title>Chronology Person Relations</title>
-		<options>
-			<option id="leader">leader</option>
-			<option id="participant">participant</option>
-			<option id="researcher">researcher</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologypeoplerelations">
-		<web-url>chronologypeoplerelations</web-url>
-		<title-ref>chronologypeoplerelations</title-ref>
-		<title>Chronology People Relations</title>
-		<options>
-			<option id="cultural_affiliation_museum">cultural affiliation by museum</option>
-			<option id="cultural_affiliation_tribe">cultural affiliation by tribe</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyorganizationrelations">
-		<web-url>chronologyorganizationrelations</web-url>
-		<title-ref>chronologyorganizationrelations</title-ref>
-		<title>Chronology Organization Relations</title>
-		<options>
-			<option id="participant">participant</option>
-			<option id="researcher">researcher</option>
-			<option id="sponsor">sponsor</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyconceptrelations">
-		<web-url>chronologyconceptrelations</web-url>
-		<title-ref>chronologyconceptrelations</title-ref>
-		<title>Chronology Concept Relations</title>
-		<options>
-			<option id="descriptor">descriptor</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyplacerelations">
-		<web-url>chronologyplacerelations</web-url>
-		<title-ref>chronologyplacerelations</title-ref>
-		<title>Chronology Place Relations</title>
-		<options>
-			<option id="current_place">current place</option>
-			<option id="historic_place">historic place</option>
-		</options>
-	</instance>
-	<instance id="vocab-chronologyrelations">
-		<web-url>chronologyrelations</web-url>
-		<title-ref>chronologyrelations</title-ref>
-		<title>Chronology Relations</title>
-		<options>
-			<option id="alternate">alternate description</option>
-			<option id="overlapping">overlapping term</option>
-		</options>
-	</instance>
 	<instance id="vocab-apparelsizes">
 		<web-url>apparelsizes</web-url>
 		<title-ref>apparelsizes</title-ref>

--- a/tomcat-main/src/main/resources/testsci-tenant.xml
+++ b/tomcat-main/src/main/resources/testsci-tenant.xml
@@ -90,6 +90,7 @@
 		    <include src="base-other-batchoutput.xml" />
 		    <include src="base-other-invocationresults.xml" />
 		    <include src="base-other-searchall.xml" />
+			<include src="base-other-associatedauthority.xml" />
 		</records>
 	</spec>
 </cspace-config>


### PR DESCRIPTION
**What does this do?**
This adds the associated authorities block to chronology, person, and place authorities. 

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1286

The associated authorities were mostly complete for 7.2 but changes were held off for the release. This adds them to the three authorities listed above  

**How should this be tested? Do these changes have associated tests?**
Along with the cspace-ui PR:

* Rebuild collectionspace so that the associated authorities block is included in chronology, person, and place
* Create a chronology, place, and person
  * When creating add an associated authority
  * Verify that the authority saves and reloads correctly  

**Dependencies for merging? Releasing to production?**
Since these fields are meant to be used in each authority, I used `base-other-associatedauthority` as it seemed like the best fit. I was considering repeating the section in each authority but this worked when testing so I stuck with it. 

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally