### PR TITLE
DRYD-1268: UCB Misc Contrib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,12 +8,7 @@ tomcat-main/plugins/
 *.eclipse.m2e.core.prefs
 tomcat-main/nb-configuration.xml
 tomcat-main/nbactions-debug.xml
-cspi-schema/diff.patch
-cspi-schema/dumpTree-1331765768078
-cspi-schema/dumpTree-1331765768078.xml
 cspi-schema/dumpedTrees/
-tomcat-main/src/main/resources/tenants/core/cow.xml
-.gitignore
 *.bak
 target/
 .DS_Store

--- a/cspi-installation/src/main/java/org/collectionspace/chain/installation/ServiceConfigGeneration.java
+++ b/cspi-installation/src/main/java/org/collectionspace/chain/installation/ServiceConfigGeneration.java
@@ -1,9 +1,11 @@
 package org.collectionspace.chain.installation;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.PrintStream;
 import java.net.URL;
 import java.util.HashMap;
@@ -94,6 +96,7 @@ public class ServiceConfigGeneration {
 	private static final String MANIFEST_FILE = "MANIFEST.MF";
 	private static final String OSGI_INF_DIR = "OSGI-INF";
 	private static final String SCHEMAS_DIR = "schemas";
+	private static final String LOGGED_SCHEMAS = "logged_schemas";
 	private static final String JAR_EXT = ".jar";	
 
 	private static final String TENANT_QUALIFIER = "Tenant";
@@ -691,6 +694,26 @@ public class ServiceConfigGeneration {
 					this.getConfigFile().getName(), schemaName);
 			log.error(errMsg);
 			throw new Exception(errMsg);
+		}
+
+		if (log.isDebugEnabled()) {
+			File loggedSchemasDir = new File(System.getProperty("user.dir"), LOGGED_SCHEMAS);
+			if (!loggedSchemasDir.exists()) {
+				loggedSchemasDir.mkdir();
+			}
+
+			String tenantConfigFileName = getConfigFile().getName();
+			String tenantDirName = tenantConfigFileName.substring(0, tenantConfigFileName.lastIndexOf('.'));
+			File tenantDir = new File(loggedSchemasDir, tenantDirName);
+			if (!tenantDir.exists()) {
+				tenantDir.mkdir();
+			}
+
+			String filePath = tenantDir + File.separator + schemaName;
+			try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath))) {
+				writer.write(contentString);
+			}
+			log.debug("Logged schema {}", filePath);
 		}
 	}
 	

--- a/tomcat-main/logged_schemas/.gitignore
+++ b/tomcat-main/logged_schemas/.gitignore
@@ -1,0 +1,2 @@
+*-tenant
+!README.txt

--- a/tomcat-main/logs/.gitignore
+++ b/tomcat-main/logs/.gitignore
@@ -1,0 +1,2 @@
+cspace-app-perflog.csv
+cspace-app-tool.log

--- a/tomcat-main/logs/README.txt
+++ b/tomcat-main/logs/README.txt
@@ -1,0 +1,1 @@
+Log files created during the schema and service bindings creation.  Use these logs to trouble-shoot schema changes and configuration changes.

--- a/tomcat-main/src/main/resources/defaults/base-procedure-exhibition.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-exhibition.xml
@@ -93,7 +93,7 @@
 		</section>
 
 		<repeat id="publishToList" services-type-anonymous="false">
-			<field id="publishTo" autocomplete="true" ui-type="enum"/>
+			<field id="publishTo" autocomplete="true" ui-type="enum" />
 		</repeat>
 	</section>
 </record>

--- a/tomcat-main/src/main/resources/tenants/anthro/domain-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/domain-instance-vocabularies.xml
@@ -98,4 +98,23 @@
 			<option id="adult_76_100">adult 76-100%</option>
 		</options>
 	</instance>
+
+	<instance id="vocab-anthroassertionnames">
+		<web-url>anthroassertionnames</web-url>
+		<title-ref>anthroassertionnames</title-ref>
+		<title>Assertion Names</title>
+		<options>
+			<option id="anthroassertionnames01">Geographic/territorial evidence</option>
+			<option id="anthroassertionnames02">Kinship evidence</option>
+			<option id="anthroassertionnames03">Biological evidence</option>
+			<option id="anthroassertionnames04">Archaeological evidence</option>
+			<option id="anthroassertionnames05">Anthropological evidence</option>
+			<option id="anthroassertionnames06">Linguistic evidence</option>
+			<option id="anthroassertionnames07">Folklore evidence</option>
+			<option id="anthroassertionnames08">Oral tradition</option>
+			<option id="anthroassertionnames09">Historical evidence</option>
+			<option id="anthroassertionnames10">Other relevant information or expert opinion</option>
+			<option id="anthroassertionnames11">Consultation summary</option>
+		</options>
+	</instance>
 </root>

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-procedure-pottag.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-procedure-pottag.xml
@@ -13,7 +13,7 @@
 	</section>
 
 	<section id="potTagInformation">
-		<field id="potTagNumber" mini="number,list" />
+		<field id="potTagNumber" mini="list" />
 	</section>
 
 	<section id="volunteerLabels">

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-procedure-pottag.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-procedure-pottag.xml
@@ -18,7 +18,7 @@
 
 	<section id="volunteerLabels">
 		<field id="family" mini="summary,list" autocomplete="true" />
-		<field id="commonName" mini="list" />
+		<field id="commonName" mini="number,list" />
 		<field id="locale" />
 		<field id="taxonName" autocomplete="true" />
 		<field id="labelData" />

--- a/tomcat-main/src/main/resources/tenants/core/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/core/settings.xml
@@ -58,7 +58,7 @@
 			</tenant>
 			<repository>
 				<domain>core-domain</domain>
-				<name>core_domain</name>
+				<name></name>
 				<client>nuxeo-java</client>
 				<dateformats>
 					<pattern>MM/dd/yyyy</pattern>

--- a/tomcat-main/src/main/resources/tenants/core/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/core/settings.xml
@@ -58,7 +58,7 @@
 			</tenant>
 			<repository>
 				<domain>core-domain</domain>
-				<name></name>
+				<name>core_domain</name>
 				<client>nuxeo-java</client>
 				<dateformats>
 					<pattern>MM/dd/yyyy</pattern>


### PR DESCRIPTION
**What does this do?**
* Add anthroassertionnames vocab
* Log schemas if debug logging is enabled
* Add mini=number to commonName for pottag
* Set name for core repository
* Updates to .gitignore

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1268

This is part of the UCB contributions. I haven't really looked over this one too much, the only thing I did was pull in various changes that weren't audit or Held-in-Trust. The `anthroassertionnames` vocab which was from their annotation-collectionobject extension commit.

**How should this be tested? Do these changes have associated tests?**
* Build collectionspace
* Check that the anthroassertionnames vocab exists
* Check the mini display for pottag commonName is correct

**Dependencies for merging? Releasing to production?**
For the schema logging, if we want to keep it we could remove the `tomcat-main/logs` and `tomcat-main/logged_schema` dirs. It should write schemas to `$HOME/logged_schemas` by the looks of things so I'm not sure what they're providing.

I wasn't sure about the settings change for the repository name and what that really affects. I haven't really had a chance to test these changes much as I was just circling back to things. 

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
No