### PR TITLE
DRYD-1316: Add object count fields and vocabulary

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -91,6 +91,13 @@
 	<section id="identificationInformation">
 		<field id="objectNumber" mini="number,list" services-refnameDisplayName="true" />
 		<field id="numberOfObjects" datatype="integer" />
+		<repeat id="objectCountGroupList/objectCountGroup">
+			<field id="objectCount" datatype="integer" />
+			<field id="objectCountType" autocomplete="true" ui-type="enum" />
+			<field id="objectCountCountedBy" autocomplete="true" />
+			<field id="objectCountDate" datatype="date" />
+			<field id="objectCountNote" />
+		</repeat>
 		<repeat id="otherNumberList/otherNumber">
 			<field id="numberValue" />
 			<field id="numberType" />

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -2131,4 +2131,15 @@
 			<option id="loan">loan</option>
 		</options>
 	</instance>
+	<instance id="vocab-objectcounttypes">
+		<web-url>objectcounttypes</web-url>
+		<title-ref>objectcounttypes</title-ref>
+		<title>Object Count Types</title>
+		<options>
+			<option id="collection_count">collection count</option>
+			<option id="inventory_count">inventory count</option>
+			<option id="associated_funerary_objects">associated funerary objects</option>
+			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
+		</options>
+	</instance>
 </instances>


### PR DESCRIPTION
**What does this do?**
Adds a new group for object count fields and vocabulary for the object count type

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1316

This is intended to replace the `numberOfObjects` field with a more complete set of fields to support reporting needs for archaeology and NAGPRA profiles. 

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* See that the new term list exists under `objectcounttypes`
* Create a collectionobject using the new fields and term

**Dependencies for merging? Releasing to production?**
As this is only the first part of the work to replace `numberOfObjects`, there are still changes which will be required in the services layer and other places to keep functionality the same as before.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance