### PR TITLE
DRYD-1206: Add nameNote field

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-authority-organization.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-organization.xml
@@ -68,6 +68,7 @@
 			<field id="contactEndDateGroup" ui-type="groupfield/structureddate" />
 			<field id="contactStatus" autocomplete="true" ui-type="enum" />
 		</repeat>
+		<field id="nameNote" />
 	</section>
 
 	<section id="contactInformation">


### PR DESCRIPTION
**What does this do?**
Adds nameNote to organization

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1206

This adds a field for storing information about organization authorities which other authorities already have.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Using the cspace-ui PR create an organization authority with the nameNote filled out
* Verify that the new field saves

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local install