### PR TITLE
DRYD-1374: Add objectcounttypes to all tenant vocabs

### DIFF
--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -1478,4 +1478,15 @@
 			<option id="supporting_collection">supporting collection</option>
 		</options>
 	</instance>
+	<instance id="vocab-objectcounttypes">
+		<web-url>objectcounttypes</web-url>
+		<title-ref>objectcounttypes</title-ref>
+		<title>Object Count Types</title>
+		<options>
+			<option id="collection_count">collection count</option>
+			<option id="inventory_count">inventory count</option>
+			<option id="associated_funerary_objects">associated funerary objects</option>
+			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
@@ -1962,5 +1962,16 @@
 			<option id="supporting_collection">supporting collection</option>
 		</options>
 	</instance>
+	<instance id="vocab-objectcounttypes">
+		<web-url>objectcounttypes</web-url>
+		<title-ref>objectcounttypes</title-ref>
+		<title>Object Count Types</title>
+		<options>
+			<option id="collection_count">collection count</option>
+			<option id="inventory_count">inventory count</option>
+			<option id="associated_funerary_objects">associated funerary objects</option>
+			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
+		</options>
+	</instance>
 	-->
 </instances>

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -1431,4 +1431,15 @@
 		</options>
 	</instance>
 	-->
+	<instance id="vocab-objectcounttypes">
+		<web-url>objectcounttypes</web-url>
+		<title-ref>objectcounttypes</title-ref>
+		<title>Object Count Types</title>
+		<options>
+			<option id="collection_count">collection count</option>
+			<option id="inventory_count">inventory count</option>
+			<option id="associated_funerary_objects">associated funerary objects</option>
+			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
@@ -2014,4 +2014,15 @@
 		</options>
 	</instance>
 	-->
+	<instance id="vocab-objectcounttypes">
+		<web-url>objectcounttypes</web-url>
+		<title-ref>objectcounttypes</title-ref>
+		<title>Object Count Types</title>
+		<options>
+			<option id="collection_count">collection count</option>
+			<option id="inventory_count">inventory count</option>
+			<option id="associated_funerary_objects">associated funerary objects</option>
+			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
+		</options>
+	</instance>
 </instances>


### PR DESCRIPTION
**What does this do?**
Adds `objectcounttypes` vocabulary to all tenants

**Why are we doing this? (with JIRA link)**
This is being done for https://collectionspace.atlassian.net/browse/DRYD-1374 where objectCount is being added in to each template which has been overridden. This work allows the `objectCountType` field to be populated for the term picker input.  

**How should this be tested? Do these changes have associated tests?**
* rebuild collectionspace with the fcart, materials, and publicart tenants enabled
* see that `objectcounttypes` exists for each tenant
  * e.g. `curl -u admin@anthro.collectionspace.org:Administrator "http://localhost:8180/cspace-services/vocabularies/urn:cspace:name(objectcounttypes)"`

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local install