### PR TITLE
DRYD-1395: Make fieldCollectionPlace repeatable

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -474,7 +474,9 @@
 		<field id="fieldCollectionFeature" />
 		<field id="fieldCollectionNote" />
 		<field id="fieldCollectionNumber" />
-		<field id="fieldCollectionPlace" autocomplete="true" />
+		<repeat id="fieldCollectionPlaces">
+			<field id="fieldCollectionPlace" autocomplete="true" />
+		</repeat>
 		<repeat id="fieldCollectionSources">
 			<field id="fieldCollectionSource" autocomplete="true" />
 		</repeat>


### PR DESCRIPTION
**What does this do?**
Creates a repeating field for fieldCollectionPlace

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1395

This updates filedCollectionPlace so that it can be repeatable, which was requested in the associated JIRA.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Check that the database tables exist for the repeating field:
```
nuxeo_default=# \d collectionobjects_common_fieldcollectionplaces
  Table "public.collectionobjects_common_fieldcollectionplaces"
 Column |         Type          | Collation | Nullable | Default 
--------+-----------------------+-----------+----------+---------
 id     | character varying(36) |           | not null | 
 pos    | integer               |           |          | 
 item   | character varying     |           |          | 
Indexes:
    "collectionobjects_common_fieldcollectionplaces_id_idx" btree (id)
    "collectionobjects_common_fieldcollectionplaces_unique_pos" UNIQUE, btree (id, pos)
Foreign-key constraints:
    "collectionobjects_common_fieldcollectionplaces_id_hierarchy_fk" FOREIGN KEY (id) REFERENCES hierarchy(id) ON DELETE CASCADE
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance