### PR TITLE
DRYD-1400: Add concept/occasion viocab to all profiles that have uoc.

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-authority-concept.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-concept.xml
@@ -61,7 +61,7 @@
 			<title-ref>materialformtype</title-ref>
 			<title>Material Form Types</title>
 		</instance>
-		<!-- For the UOC Occassion field -->
+		<!-- For the UOC Occasion field -->
 		<instance id="concept-occasion">
 			<web-url>occasion</web-url>
 			<title-ref>occasion</title-ref>

--- a/tomcat-main/src/main/resources/defaults/extensions/fineart-authority-concept.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fineart-authority-concept.xml
@@ -30,6 +30,12 @@
 			<title-ref>nomenclature</title-ref>
 			<title>Nomenclature</title>
 		</instance>
+		<!-- For the UOC Occasion field -->
+		<instance id="concept-occasion">
+			<web-url>occasion</web-url>
+			<title-ref>occasion</title-ref>
+			<title>Occasion Concepts</title>
+		</instance>
 	</instances>
 
 	<section id="conceptAuthorityInformation">

--- a/tomcat-main/src/main/resources/tenants/anthro/anthro-authority-concept.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/anthro-authority-concept.xml
@@ -35,5 +35,11 @@
 			<title-ref>ethfilecode</title-ref>
 			<title>Ethnographic File Codes</title>
 		</instance>
+		<!-- For the UOC Occasion field -->
+		<instance id="concept-occasion">
+			<web-url>occasion</web-url>
+			<title-ref>occasion</title-ref>
+			<title>Occasion Concepts</title>
+		</instance>
 	</instances>
 </record>

--- a/tomcat-main/src/main/resources/tenants/herbarium/herbarium-authority-concept.xml
+++ b/tomcat-main/src/main/resources/tenants/herbarium/herbarium-authority-concept.xml
@@ -32,6 +32,12 @@
 			<title-ref>materialformtype</title-ref>
 			<title>Material Form Types</title>
 		</instance>
+		<!-- For the UOC Occasion field -->
+		<instance id="concept-occasion">
+			<web-url>occasion</web-url>
+			<title-ref>occasion</title-ref>
+			<title>Occasion Concepts</title>
+		</instance>
 		<!-- For herbarium profile -->
 		<instance id="concept-labeltext">
 			<web-url>labeltext</web-url>

--- a/tomcat-main/src/main/resources/tenants/materials/materials-authority-concept.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/materials-authority-concept.xml
@@ -12,5 +12,11 @@
 			<title>Shared Material Classifications</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
+		<!-- For the UOC Occasion field -->
+		<instance id="concept-occasion">
+			<web-url>occasion</web-url>
+			<title-ref>occasion</title-ref>
+			<title>Occasion Concepts</title>
+		</instance>
 	</instances>
 </record>


### PR DESCRIPTION
**What does this do?**

This adds the concept/occasion vocabulary to all profiles that have the Use of Collections procedure (which has a field that references that vocabulary). Previously, the vocabulary was missing from fcart, anthro, herbarium, and materials.

**Why are we doing this? (with JIRA link)**

Some profiles that had the Use of Collections procedure didn't have the Concept/Occasion vocabulary, so the Occasion field couldn't be filled in.

JIRA: https://collectionspace.atlassian.net/browse/DRYD-1400

**How should this be tested? Do these changes have associated tests?**

In the fcart, anthro, herbarium, and materials tenants:
- On Create New, verify that Occasion is listed as a Concept 
- Create a Use of Collections record, and enter a value in the Occasion field. It should be possible to enter a value, and the value should be retained after save.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee verified locally.