### PR TITLE
Add associated authority relation vocab

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -2053,4 +2053,25 @@
 			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
 		</options>
 	</instance>
+	<instance id="vocab-assocauthorityrelationtype">
+		<web-url>assocauthorityrelationtype</web-url>
+		<title-ref>assocauthorityrelationtype</title-ref>
+		<title>Associated Authority Relation Types</title>
+		<options>
+			<option id="affiliated">affiliated</option>
+			<option id="affiliated_to">affiliated to</option>
+			<option id="collector">collector</option>
+			<option id="collected_by">collected by</option>
+			<option id="family_member">family member</option>
+			<option id="leader">leader</option>
+			<option id="leader_of">leader of</option>
+			<option id="owner">owner</option>
+			<option id="owned_by">owned by</option>
+			<option id="replica">replica</option>
+			<option id="replica_of">replica of</option>
+			<option id="resident">resident</option>
+			<option id="place_of_residence">place of residence</option>
+			<option id="situated_in">situated in</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -1489,4 +1489,25 @@
 			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
 		</options>
 	</instance>
+	<instance id="vocab-assocauthorityrelationtype">
+		<web-url>assocauthorityrelationtype</web-url>
+		<title-ref>assocauthorityrelationtype</title-ref>
+		<title>Associated Authority Relation Types</title>
+		<options>
+			<option id="affiliated">affiliated</option>
+			<option id="affiliated_to">affiliated to</option>
+			<option id="collector">collector</option>
+			<option id="collected_by">collected by</option>
+			<option id="family_member">family member</option>
+			<option id="leader">leader</option>
+			<option id="leader_of">leader of</option>
+			<option id="owner">owner</option>
+			<option id="owned_by">owned by</option>
+			<option id="replica">replica</option>
+			<option id="replica_of">replica of</option>
+			<option id="resident">resident</option>
+			<option id="place_of_residence">place of residence</option>
+			<option id="situated_in">situated in</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
@@ -1973,5 +1973,26 @@
 			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
 		</options>
 	</instance>
+	<instance id="vocab-assocauthorityrelationtype">
+		<web-url>assocauthorityrelationtype</web-url>
+		<title-ref>assocauthorityrelationtype</title-ref>
+		<title>Associated Authority Relation Types</title>
+		<options>
+			<option id="affiliated">affiliated</option>
+			<option id="affiliated_to">affiliated to</option>
+			<option id="collector">collector</option>
+			<option id="collected_by">collected by</option>
+			<option id="family_member">family member</option>
+			<option id="leader">leader</option>
+			<option id="leader_of">leader of</option>
+			<option id="owner">owner</option>
+			<option id="owned_by">owned by</option>
+			<option id="replica">replica</option>
+			<option id="replica_of">replica of</option>
+			<option id="resident">resident</option>
+			<option id="place_of_residence">place of residence</option>
+			<option id="situated_in">situated in</option>
+		</options>
+	</instance>
 	-->
 </instances>

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -1442,4 +1442,27 @@
 			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
 		</options>
 	</instance>
+	<!--
+	<instance id="vocab-assocauthorityrelationtype">
+		<web-url>assocauthorityrelationtype</web-url>
+		<title-ref>assocauthorityrelationtype</title-ref>
+		<title>Associated Authority Relation Types</title>
+		<options>
+			<option id="affiliated">affiliated</option>
+			<option id="affiliated_to">affiliated to</option>
+			<option id="collector">collector</option>
+			<option id="collected_by">collected by</option>
+			<option id="family_member">family member</option>
+			<option id="leader">leader</option>
+			<option id="leader_of">leader of</option>
+			<option id="owner">owner</option>
+			<option id="owned_by">owned by</option>
+			<option id="replica">replica</option>
+			<option id="replica_of">replica of</option>
+			<option id="resident">resident</option>
+			<option id="place_of_residence">place of residence</option>
+			<option id="situated_in">situated in</option>
+		</options>
+	</instance>
+	-->
 </instances>

--- a/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
@@ -2025,4 +2025,27 @@
 			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
 		</options>
 	</instance>
+	<!--
+	<instance id="vocab-assocauthorityrelationtype">
+		<web-url>assocauthorityrelationtype</web-url>
+		<title-ref>assocauthorityrelationtype</title-ref>
+		<title>Associated Authority Relation Types</title>
+		<options>
+			<option id="affiliated">affiliated</option>
+			<option id="affiliated_to">affiliated to</option>
+			<option id="collector">collector</option>
+			<option id="collected_by">collected by</option>
+			<option id="family_member">family member</option>
+			<option id="leader">leader</option>
+			<option id="leader_of">leader of</option>
+			<option id="owner">owner</option>
+			<option id="owned_by">owned by</option>
+			<option id="replica">replica</option>
+			<option id="replica_of">replica of</option>
+			<option id="resident">resident</option>
+			<option id="place_of_residence">place of residence</option>
+			<option id="situated_in">situated in</option>
+		</options>
+	</instance>
+	 -->
 </instances>


### PR DESCRIPTION
**What does this do?**
Adds a vocab for the associated authority relation type

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1286

This adds a new vocabulary for use with the associated authority extension as the relationtypetype was deemed unsuitable. 

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace with core, anthro, fcart, and lhmc enabled
* Check that the vocabulary exists for each tenant, e.g.
```
curl -u 'admin@core.collectionspace.org:Administrator' "http://localhost:8180/cspace-services/vocabularies/urn:cspace:name(assocauthorityrelationtype)/items"
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally for core