### PR TITLE
DRYD-1358: Held-in-Trust Updates

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -2213,4 +2213,31 @@
 			<option id="email">email</option>
 		</options>
 	</instance>
+	<instance id="vocab-limitationtype">
+		<web-url>limitationtype</web-url>
+		<title-ref>limitationtype</title-ref>
+		<title>Access Limitation Type</title>
+		<options>
+			<option id="display_visual">display/visual</option>
+			<option id="handling_gender">handling - gender</option>
+			<option id="handling_other">handling - other</option>
+			<option id="lending">lending</option>
+			<option id="publication">publication</option>
+			<option id="research_access">research/access</option>
+			<option id="storage">storage</option>
+			<option id="treatment">treatment</option>
+			<option id="unknown">unknown</option>
+		</options>
+	</instance>
+	<instance id="vocab-limitationlevel">
+		<web-url>limitationlevel</web-url>
+		<title-ref>limitationlevel</title-ref>
+		<title>Access Limitation Level</title>
+		<options>
+			<option id="preference">preference</option>
+			<option id="recommendation">recommendation</option>
+			<option id="restriction">restriction</option>
+			<option id="unknown">unknown</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -2182,6 +2182,9 @@
 		<title-ref>heldintrusttype</title-ref>
 		<title>HeldInTrust Type</title>
 		<options>
+			<option id="mou">MOU</option>
+			<option id="repatriation_agreement">repatriation agreement</option>
+			<option id="temporary">temporary</option>
 		</options>
 	</instance>
 	<instance id="vocab-heldintruststatus">

--- a/tomcat-main/src/main/resources/defaults/base-procedure-heldintrust.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-heldintrust.xml
@@ -46,4 +46,18 @@
     </repeat>
   </section>
 
+  <section id="culturalCareInformation">
+    <repeat id="culturalCareNotes">
+      <field id="culturalCareNote" />
+    </repeat>
+    <repeat id="accessLimitationsGroupList/accessLimitationsGroup">
+      <field id="limitationType" autocomplete="true" ui-type="enum" />
+      <field id="limitationLevel" autocomplete="true" ui-type="enum" />
+      <field id="limitationDetails" />
+      <field id="requester" autocomplete="true" />
+      <field id="requestOnBehalfOf" autocomplete="true" />
+      <field id="requestDate" datatype="date" />
+    </repeat>
+  </section>
+
 </record>


### PR DESCRIPTION
**What does this do?**
* Adds cultural care fields to Held-in-Trust
* Update default values for heldintrusttype 
* Add limitationtype and limitationlevel terms to base vocabs

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1358

Instead of creating a new CulturalCare procedure, we're opting to pull the cultural care fields directly into Held-in-Trust. Along with this we're adding the existing term lists for cultural care into the base-vocabularies so that they can be used in core.

This is also updating the default terms for heldintrusttype, which we were previously waiting on.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Use the cspace-ui PR to create a Held-in-Trust record with cultural care fields

**Dependencies for merging? Releasing to production?**
I didn't update the culturalcare-vocabularies yet or remove it from the lhmc or anthro config. Since these PRs have been focused on core, I've only made changes with that in mind. For this I could go and update lhmc and anthro though.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance