### PR TITLE
Duty of Care Updates

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-procedure-dutyofcare.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-dutyofcare.xml
@@ -15,7 +15,7 @@
   <section id="dutyOfCareInformation">
     <field id="dutyOfCareNumber" mini="number,list" />
     <field id="originationDate" datatype="date" />
-    <field id="title" mini="summary,list" />
+    <field id="dutyOfCareTitle" mini="summary,list" />
     <repeat id="notes">
       <field id="note" />
     </repeat>

--- a/tomcat-main/src/main/resources/defaults/base-procedure-dutyofcare.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-dutyofcare.xml
@@ -1,9 +1,9 @@
 <record id="dutyofcare" in-findedit="yes" type="record,procedure" cms-type="default" generate-services-schema="true" >
-  <services-url>dutyofcares</services-url>
-  <services-tenant-plural>Dutyofcares</services-tenant-plural>
+  <services-url>dutiesofcare</services-url>
+  <services-tenant-plural>Dutiesofcare</services-tenant-plural>
   <services-tenant-singular>Dutyofcare</services-tenant-singular>
   <services-list-path>abstract-common-list/list-item</services-list-path>
-  <services-record-path>dutyofcares_common:http://collectionspace.org/services/dutyofcare,dutyofcares_common</services-record-path>
+  <services-record-path>dutiesofcare_common:http://collectionspace.org/services/dutyofcare,dutiesofcare_common</services-record-path>
   <services-record-path id="collectionspace_core">collectionspace_core:http://collectionspace.org/collectionspace_core/,collectionspace_core</services-record-path>
 
   <include src="domain-procedure-dutyofcare.xml" strip-root="yes" />


### PR DESCRIPTION
**What does this do?**
* Fix pluralization for duty of care
* Change title to dutyOfCareTitle

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1332

These changes come from the testing done against Duty of Care. The pluralization update which was requested is being applied here for consistency throughout the procedure. 

I also noticed that the `title` field exists in the dublin core schema, which was sometimes being pulled back in the search results, so I've updated the field definition to be `dutyOfCareTitle` to avoid that collision. I saw some procedures use `services-schema-qualift` with their title field, but I'm not _too_ familiar with what that's doing so I did a quick update of the name. Other NAGPRA procedures will likely hit the same issue so if that's simpler it might be a better fix.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace
* Test that the Duty of Care service is accessible on the new uri
```
curl --user 'admin@core.collectionspace.org:Administrator' http://localhost:8180/cspace-services/dutiesofcare
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance