### PR TITLE
DRYD-1436: Add related link group

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -460,6 +460,11 @@
 			<field id="reference" autocomplete="true" />
 			<field id="referenceNote" />
 		</repeat>
+
+		<repeat id="relatedLinkGroupList/relatedLinkGroup">
+			<field id="relatedURL" />
+			<field id="descriptiveTitle" />
+		</repeat>
 	</section>
 	<section id="objectCollectionInformation">
 		<repeat id="fieldCollectionSites">

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -461,8 +461,8 @@
 			<field id="referenceNote" />
 		</repeat>
 
-		<repeat id="relatedLinkGroupList/relatedLinkGroup">
-			<field id="relatedURL" />
+		<repeat id="publishedRelatedLinkGroupList/publishedRelatedLinkGroup">
+			<field id="relatedLink" />
 			<field id="descriptiveTitle" />
 		</repeat>
 	</section>


### PR DESCRIPTION
**What does this do?**
* Add related link group to collectionobject

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1436

This adds related links to the reference information section for collectionobjects.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Using the related cspace-ui PR: 
  * Create a collectionobject and scroll to the Reference Information section
  * See that the related link group exists and can be filled out
  * Switch to the public browser template and see the same as the above

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally