### PR TITLE
ObjectExit and Deaccession Term Lists

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -2375,4 +2375,14 @@
 			<option id="return_to_donor">return to donor</option>
 		</options>
 	</instance>
+	<instance id="vocab-exitreason">
+		<web-url>exitreason</web-url>
+		<title-ref>exitreason</title-ref>
+		<title>Exit Reason</title>
+		<options>
+			<option id="deaccession">deaccession</option>
+			<option id="return_intake">return of intake</option>
+			<option id="return_loan">return of loan</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -2349,4 +2349,16 @@
 			<option id="tribal">tribal</option>
 		</options>
 	</instance>
+	<instance id="vocab-deaccessionreason">
+		<web-url>deaccessionreason</web-url>
+		<title-ref>deaccessionreason</title-ref>
+		<title>Deaccession Reason</title>
+		<options>
+			<option id="condition">condition</option>
+			<option id="missing">missing</option>
+			<option id="repatriation">repatriation</option>
+			<option id="stolen">stolen</option>
+			<option id="no_longer_fits_policy">no longer fits collection policy</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -2361,4 +2361,18 @@
 			<option id="no_longer_fits_policy">no longer fits collection policy</option>
 		</options>
 	</instance>
+	<instance id="vocab-exitmethod">
+		<web-url>exitmethod</web-url>
+		<title-ref>exitmethod</title-ref>
+		<title>Exit Method</title>
+		<options>
+			<option id="auction">auction</option>
+			<option id="disposal">disposal</option>
+			<option id="donation">donation</option>
+			<option id="exchange">exchange</option>
+			<option id="repatriation">repatriation</option>
+			<option id="private_sale">private sale</option>
+			<option id="return_to_donor">return to donor</option>
+		</options>
+	</instance>
 </instances>


### PR DESCRIPTION
**What does this do?**
* Add Deaccession Reason
* Add Exit Reason
* Add Exit Method

**Why are we doing this? (with JIRA link)**
* https://collectionspace.atlassian.net/browse/DRYD-1480
* https://collectionspace.atlassian.net/browse/DRYD-1481
* https://collectionspace.atlassian.net/browse/DRYD-1484

These are new term lists which will be required for the new Deaccession and Object Exit procedures.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace
* Query the vocabularies endpoint for the new vocabs, e.g.
```
curl -u admin@core.collectionspace.org:Administrator "http://localhost:8180/cspace-services/vocabularies/urn:cspace:name(deaccessionreason)/items"
```

**Dependencies for merging? Releasing to production?**
Will need to be added to other profiles, maybe should just be done now?

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter rebuilt and saw the new term lists in the db