### PR TITLE
Held-in-Trust QA Updates

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-procedure-heldintrust.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-heldintrust.xml
@@ -30,7 +30,7 @@
     </repeat>
 
     <repeat id="agreementApprovalGroupList/agreementApprovalGroup">
-      <field id="agreementGroup" />
+      <field id="agreementGroup" autocomplete="true" ui-type="enum" />
       <field id="agreementIndividual" autocomplete="true" />
       <field id="agreementStatus" autocomplete="true" ui-type="enum" />
       <field id="agreementDate" datatype="date" />


### PR DESCRIPTION
**What does this do?**
* Updates agreementGroup to be an enum type

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1358

Part of the initial QA updates was to update the agreementGroup to be controlled by `deaccessionapprovalgroup`. This updates the schema so that cspace is aware the field is being used as an enum type.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace
* Test with the related cspace-ui PR

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local install