### PR TITLE
DRYD-1476: Remove unused term lists

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -2116,20 +2116,6 @@
 			<option id="unknown">unknown</option>
 		</options>
 	</instance>
-	<instance id="vocab-nagprastatus">
-		<web-url>nagprastatus</web-url>
-		<title-ref>nagprastatus</title-ref>
-		<title>NAGPRA Status</title>
-		<options>
-			<option id="under_review">under review</option>
-			<option id="under_consultation">under consultation</option>
-			<option id="fulfilled">fulfilled</option>
-			<option id="partially_fulfilled">partially fulfilled</option>
-			<option id="under_arbitration">under arbitration</option>
-			<option id="denied">denied</option>
-			<option id="withdrawn">withdrawn</option>
-		</options>
-	</instance>
 	<instance id="vocab-nagpradocumentationstatus">
 		<web-url>nagpradocumentationstatus</web-url>
 		<title-ref>nagpradocumentationstatus</title-ref>
@@ -2170,19 +2156,6 @@
 			<option id="pending">pending</option>
 		</options>
 	</instance>
-	<instance id="vocab-nagprainvstate">
-		<web-url>nagprainvstate</web-url>
-		<title-ref>nagprainvstate</title-ref>
-		<title>NAGPRA Inventory State</title>
-		<options>
-			<option id="in_development">in development</option>
-			<option id="under_construction">under construction</option>
-			<option id="submitted">submitted</option>
-			<option id="preliminary">preliminary</option>
-			<option id="claimed">claimed</option>
-			<option id="partially_claimed">partially claimed</option>
-		</options>
-	</instance>
 	<instance id="vocab-summarydocumentationtype">
 		<web-url>summarydocumentationtype</web-url>
 		<title-ref>summarydocumentationtype</title-ref>
@@ -2201,21 +2174,6 @@
 			<option id="mou">MOU</option>
 			<option id="repatriation_agreement">repatriation agreement</option>
 			<option id="temporary">temporary</option>
-		</options>
-	</instance>
-	<instance id="vocab-heldintruststatus">
-		<web-url>heldintruststatus</web-url>
-		<title-ref>heldintruststatus</title-ref>
-		<title>HeldInTrust Status</title>
-		<options>
-			<option id="agreed">agreed</option>
-			<option id="authorized">authorized</option>
-			<option id="cancelled">cancelled</option>
-			<option id="refused">refused</option>
-			<option id="renewed">renewed</option>
-			<option id="requested">requested</option>
-			<option id="returned">returned</option>
-			<option id="sent">sent</option>
 		</options>
 	</instance>
 	<instance id="vocab-correspondencetype">


### PR DESCRIPTION
**What does this do?**
* Remove nagprastatus
* Remove nagprainvstate
* Remove heldintruststatus

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1476

These are all term lists which were determined not to be necessary for the new NAGPRA workflows and are being removed.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace
* Test that the new terms don't exist, e.g.
```
curl -v -u admin@core.collectionspace.org:Administrator http://localhost:8180/cspace-services/vocabularies/urn:cspace:name(nagpra)
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Also no... can be tested if wanted but it's only removals