### PR TITLE
DRYD-1498: Object Category Extension

### DIFF
--- a/tomcat-main/src/main/resources/anthro-tenant.xml
+++ b/tomcat-main/src/main/resources/anthro-tenant.xml
@@ -11,7 +11,7 @@
 		<records>
 			<enum-blank>Please select a value</enum-blank>
 
-			<include src="base-collectionobject.xml,extensions/culturalcare-collectionobject.xml,extensions/nagpra-collectionobject.xml,extensions/naturalhistory-collectionobject.xml,anthro-collectionobject.xml" merge="xmlmerge.properties" />
+			<include src="base-collectionobject.xml,extensions/culturalcare-collectionobject.xml,extensions/nagpra-collectionobject.xml,extensions/naturalhistory-collectionobject.xml,extensions/objectcategory-collectionobject.xml,anthro-collectionobject.xml" merge="xmlmerge.properties" />
 			<include src="base-authority.xml" />
 
 			<include src="base-procedure-acquisition.xml" />

--- a/tomcat-main/src/main/resources/defaults/extensions/objectcategory-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/objectcategory-collectionobject.xml
@@ -1,0 +1,11 @@
+<record id="collection-object" is-extension="true">
+	<services-record-path id="objectcategory_extension">collectionobjects_objectcategory_extension:http://collectionspace.org/services/collectionobject/domain/objectcategory_extension,collectionobjects_objectcategory_extension</services-record-path>
+	<section id="identificationInformation">
+    <repeat id="objectCategoryGroupList/objectCategoryGroup" section="objectcategory_extension">
+      <field id="category" autocomplete="true" ui-type="enum" section="objectcategory_extension" />
+      <field id="categoryCount" datatype="integer" section="objectcategory_extension" />
+      <field id="categoryCountUnit" autocomplete="true" ui-type="enum" section="objectcategory_extension" />
+      <field id="categoryNote" section="objectcategory_extension" />
+    </repeat>
+	</section>
+</record>

--- a/tomcat-main/src/main/resources/defaults/extensions/objectcategory-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/objectcategory-vocabularies.xml
@@ -1,0 +1,26 @@
+<instances>
+  <instance id="vocab-objectcategory">
+    <web-url>objectcategory</web-url>
+    <title-ref>objectcategory</title-ref>
+    <title>Object Category</title>
+    <options>
+      <option id="debitage">debitage</option>
+      <option id="ethnographic">ethnographic</option>
+      <option id="historics">historics</option>
+      <option id="human_remains">human remains</option>
+      <option id="modified_faunal_remains">modified faunal remains</option>
+      <option id="modified_floral_remains">modified floral remains</option>
+      <option id="modified_human_remains">modified human remains</option>
+      <option id="modified_mineral">modified mineral</option>
+      <option id="modified_shell">modified shell</option>
+      <option id="modified_stone">modified stone</option>
+      <option id="soil">soil</option>
+      <option id="unidentified">unidentified</option>
+      <option id="unmodified_faunal_remains">unmodified faunal remains</option>
+      <option id="unmodified_floral_remains">unmodified floral remains</option>
+      <option id="unmodified_mineral">unmodified mineral</option>
+      <option id="unmodified_shell">unmodified shell</option>
+      <option id="unmodified_stone">unmodified stone</option>
+    </options>
+  </instance>
+</instances>

--- a/tomcat-main/src/main/resources/tenants/anthro/domain-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/domain-instance-vocabularies.xml
@@ -5,6 +5,7 @@
 	<include src="extensions/locality-vocabularies.xml" strip-root="yes" />
 	<include src="extensions/nagpra-vocabularies.xml" strip-root="yes" />
 	<include src="extensions/naturalhistory-vocabularies.xml" strip-root="yes" />
+	<include src="extensions/objectcategory-vocabularies.xml" strip-root="yes" />
 
 	<instance id="vocab-prodtechniquetype">
 		<web-url>prodtechniquetype</web-url>


### PR DESCRIPTION
**What does this do?**
* Add object category fields as an extension
* Add term list for object category

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1498

This is a new block of fields intended to be used with the anthro profile.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace with anthro enabled
* Test using the related cspace-ui pr

**Dependencies for merging? Releasing to production?**
The extension namespace is kind of long, could be trimmed down. Not really a blocker though.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally
