### PR TITLE
DRYD-1503: Production Place Verbatim

### DIFF
--- a/tomcat-main/src/main/resources/anthro-tenant.xml
+++ b/tomcat-main/src/main/resources/anthro-tenant.xml
@@ -11,7 +11,8 @@
 		<records>
 			<enum-blank>Please select a value</enum-blank>
 
-			<include src="base-collectionobject.xml,extensions/culturalcare-collectionobject.xml,extensions/nagpra-collectionobject.xml,extensions/naturalhistory-collectionobject.xml,extensions/objectcategory-collectionobject.xml,anthro-collectionobject.xml" merge="xmlmerge.properties" />
+			<include src="base-collectionobject.xml,extensions/culturalcare-collectionobject.xml,extensions/nagpra-collectionobject.xml,extensions/naturalhistory-collectionobject.xml,
+										extensions/objectcategory-collectionobject.xml,anthro-collectionobject.xml,extensions/objectproduction-collectionobject.xml" merge="xmlmerge.properties" />
 			<include src="base-authority.xml" />
 
 			<include src="base-procedure-acquisition.xml" />

--- a/tomcat-main/src/main/resources/defaults/extensions/objectproduction-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/objectproduction-collectionobject.xml
@@ -1,8 +1,8 @@
 <record id="collection-object" is-extension="true">
   <services-record-path id="objectprod_extension">collectionobjects_objectprod_extension:http://collectionspace.org/services/collectionobject/domain/objectprod_extension,collectionobjects_objectprod_extension</services-record-path>
   <section id="objectProductionInformation" section="objectprod_extension">
-    <repeat id="objectProductionLocationsVerbatim" section="objectprod_extension">
-      <field id="objectProductionLocationVerbatim" section="objectprod_extension" />
+    <repeat id="objectProductionPlacesVerbatim" section="objectprod_extension">
+      <field id="objectProductionPlaceVerbatim" section="objectprod_extension" />
     </repeat>
   </section>
 </record>

--- a/tomcat-main/src/main/resources/defaults/extensions/objectproduction-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/objectproduction-collectionobject.xml
@@ -1,0 +1,8 @@
+<record id="collection-object" is-extension="true">
+  <services-record-path id="objectprod_extension">collectionobjects_objectprod_extension:http://collectionspace.org/services/collectionobject/domain/objectprod_extension,collectionobjects_objectprod_extension</services-record-path>
+  <section id="objectProductionInformation" section="objectprod_extension">
+    <repeat id="objectProductionLocationsVerbatim" section="objectprod_extension">
+      <field id="objectProductionLocationVerbatim" section="objectprod_extension" />
+    </repeat>
+  </section>
+</record>

--- a/tomcat-main/src/main/resources/fcart-tenant.xml
+++ b/tomcat-main/src/main/resources/fcart-tenant.xml
@@ -11,8 +11,8 @@
 		<records>
 			<enum-blank>Please select a value</enum-blank>
 
-			<include src="base-collectionobject.xml,extensions/variablemedia-collectionobject.xml,extensions/fineart-collectionobject.xml,extensions/fcart-profile-collectionobject.xml"
-                     merge="xmlmerge.properties" />
+			<include src="base-collectionobject.xml,extensions/variablemedia-collectionobject.xml,extensions/fineart-collectionobject.xml,extensions/fcart-profile-collectionobject.xml,
+										extensions/objectproduction-collectionobject.xml" merge="xmlmerge.properties" />
 			<include src="base-authority.xml" />
 
 			<include src="base-procedure-acquisition.xml" />

--- a/tomcat-main/src/main/resources/lhmc-tenant.xml
+++ b/tomcat-main/src/main/resources/lhmc-tenant.xml
@@ -10,7 +10,8 @@
 		<records>
 			<enum-blank>Please select a value</enum-blank>
 
-			<include src="base-collectionobject.xml,lhmc-collectionobject.xml,extensions/culturalcare-collectionobject.xml" merge="xmlmerge.properties" />
+			<include src="base-collectionobject.xml,lhmc-collectionobject.xml,extensions/culturalcare-collectionobject.xml,extensions/objectproduction-collectionobject.xml"
+										merge="xmlmerge.properties" />
 			<include src="base-authority.xml" />
 
 			<include src="base-procedure-acquisition.xml,lhmc-procedure-acquisition.xml" merge="xmlmerge.properties" />


### PR DESCRIPTION
**What does this do?**
* Add production place verbatim field as an extension

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1503

This field was requested to be added for the 8.1 release. As it is only going in a few profiles, it is being done as an extension rather than a part of the base collectionobject.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace with this PR
* Using one of the anthro, fcart, or lhmc PRs:
 * Create a collectionobject with the new field (production place verbatim)
 * Ensure the new field saves and loads

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested on a local instance using anthro