### PR TITLE
Update new Object Exit term lists

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -2320,27 +2320,27 @@
 			<option id="nagpra_repatriation">NAGPRA repatriation</option>
 		</options>
 	</instance>
-	<instance id="vocab-exitmethod">
-		<web-url>exitmethod</web-url>
-		<title-ref>exitmethod</title-ref>
-		<title>Exit Method</title>
+	<instance id="vocab-objexitmethod">
+		<web-url>objexitmethod</web-url>
+		<title-ref>objexitmethod</title-ref>
+		<title>Object Exit Methods</title>
 		<options>
 			<option id="auction">auction</option>
-			<option id="disposal">disposal</option>
 			<option id="donation">donation</option>
-			<option id="exchange">exchange</option>
 			<option id="repatriation">repatriation</option>
-			<option id="private_sale">private sale</option>
-			<option id="return_to_donor">return to donor</option>
+			<option id="sale">sale</option>
+			<option id="shred">shred</option>
+			<option id="trash_disposal">trash disposal</option>
 		</options>
 	</instance>
-	<instance id="vocab-exitreason">
-		<web-url>exitreason</web-url>
-		<title-ref>exitreason</title-ref>
-		<title>Exit Reason</title>
+	<instance id="vocab-objexitreason">
+		<web-url>objexitreason</web-url>
+		<title-ref>objexitreason</title-ref>
+		<title>Object Exit Reasons</title>
 		<options>
 			<option id="deaccession">deaccession</option>
-			<option id="return_intake">return of intake</option>
+			<option id="disposal">disposal</option>
+			<option id="repatriation">repatriation</option>
 			<option id="return_loan">return of loan</option>
 		</options>
 	</instance>

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -1525,4 +1525,41 @@
 			<option id="set">set</option>
 		</options>
 	</instance>
+	<instance id="vocab-deaccessionreason">
+		<web-url>deaccessionreason</web-url>
+		<title-ref>deaccessionreason</title-ref>
+		<title>Deaccession Reason</title>
+		<options>
+			<option id="no_longer_useful">no longer useful to the organization purpose</option>
+			<option id="does_not_fit">does not fit collecting policy</option>
+			<option id="deteriorated">has deteriorated beyond usefulness</option>
+			<option id="no_longer_preserved">can no longer be preserved</option>
+			<option id="has_better_example">is represented by a better example</option>
+			<option id="nagpra_repatriation">NAGPRA repatriation</option>
+		</options>
+	</instance>
+	<instance id="vocab-objexitmethod">
+		<web-url>objexitmethod</web-url>
+		<title-ref>objexitmethod</title-ref>
+		<title>Object Exit Methods</title>
+		<options>
+			<option id="auction">auction</option>
+			<option id="donation">donation</option>
+			<option id="repatriation">repatriation</option>
+			<option id="sale">sale</option>
+			<option id="shred">shred</option>
+			<option id="trash_disposal">trash disposal</option>
+		</options>
+	</instance>
+	<instance id="vocab-exitreason">
+		<web-url>objexitreason</web-url>
+		<title-ref>objexitreason</title-ref>
+		<title>Object Exit Reasons</title>
+		<options>
+			<option id="deaccession">deaccession</option>
+			<option id="disposal">disposal</option>
+			<option id="repatriation">repatriation</option>
+			<option id="return_loan">return of loan</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -1525,19 +1525,6 @@
 			<option id="set">set</option>
 		</options>
 	</instance>
-	<instance id="vocab-deaccessionreason">
-		<web-url>deaccessionreason</web-url>
-		<title-ref>deaccessionreason</title-ref>
-		<title>Deaccession Reason</title>
-		<options>
-			<option id="no_longer_useful">no longer useful to the organization purpose</option>
-			<option id="does_not_fit">does not fit collecting policy</option>
-			<option id="deteriorated">has deteriorated beyond usefulness</option>
-			<option id="no_longer_preserved">can no longer be preserved</option>
-			<option id="has_better_example">is represented by a better example</option>
-			<option id="nagpra_repatriation">NAGPRA repatriation</option>
-		</options>
-	</instance>
 	<instance id="vocab-objexitmethod">
 		<web-url>objexitmethod</web-url>
 		<title-ref>objexitmethod</title-ref>

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
@@ -2009,5 +2009,42 @@
 			<option id="set">set</option>
 		</options>
 	</instance>
+	<instance id="vocab-deaccessionreason">
+		<web-url>deaccessionreason</web-url>
+		<title-ref>deaccessionreason</title-ref>
+		<title>Deaccession Reason</title>
+		<options>
+			<option id="no_longer_useful">no longer useful to the organization purpose</option>
+			<option id="does_not_fit">does not fit collecting policy</option>
+			<option id="deteriorated">has deteriorated beyond usefulness</option>
+			<option id="no_longer_preserved">can no longer be preserved</option>
+			<option id="has_better_example">is represented by a better example</option>
+			<option id="nagpra_repatriation">NAGPRA repatriation</option>
+		</options>
+	</instance>
+	<instance id="vocab-objexitmethod">
+		<web-url>objexitmethod</web-url>
+		<title-ref>objexitmethod</title-ref>
+		<title>Object Exit Methods</title>
+		<options>
+			<option id="auction">auction</option>
+			<option id="donation">donation</option>
+			<option id="repatriation">repatriation</option>
+			<option id="sale">sale</option>
+			<option id="shred">shred</option>
+			<option id="trash_disposal">trash disposal</option>
+		</options>
+	</instance>
+	<instance id="vocab-exitreason">
+		<web-url>objexitreason</web-url>
+		<title-ref>objexitreason</title-ref>
+		<title>Object Exit Reasons</title>
+		<options>
+			<option id="deaccession">deaccession</option>
+			<option id="disposal">disposal</option>
+			<option id="repatriation">repatriation</option>
+			<option id="return_loan">return of loan</option>
+		</options>
+	</instance>
 	-->
 </instances>

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
@@ -2009,19 +2009,6 @@
 			<option id="set">set</option>
 		</options>
 	</instance>
-	<instance id="vocab-deaccessionreason">
-		<web-url>deaccessionreason</web-url>
-		<title-ref>deaccessionreason</title-ref>
-		<title>Deaccession Reason</title>
-		<options>
-			<option id="no_longer_useful">no longer useful to the organization purpose</option>
-			<option id="does_not_fit">does not fit collecting policy</option>
-			<option id="deteriorated">has deteriorated beyond usefulness</option>
-			<option id="no_longer_preserved">can no longer be preserved</option>
-			<option id="has_better_example">is represented by a better example</option>
-			<option id="nagpra_repatriation">NAGPRA repatriation</option>
-		</options>
-	</instance>
 	<instance id="vocab-objexitmethod">
 		<web-url>objexitmethod</web-url>
 		<title-ref>objexitmethod</title-ref>

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -1480,4 +1480,41 @@
 			<option id="set">set</option>
 		</options>
 	</instance>
+	<instance id="vocab-deaccessionreason">
+		<web-url>deaccessionreason</web-url>
+		<title-ref>deaccessionreason</title-ref>
+		<title>Deaccession Reason</title>
+		<options>
+			<option id="no_longer_useful">no longer useful to the organization purpose</option>
+			<option id="does_not_fit">does not fit collecting policy</option>
+			<option id="deteriorated">has deteriorated beyond usefulness</option>
+			<option id="no_longer_preserved">can no longer be preserved</option>
+			<option id="has_better_example">is represented by a better example</option>
+			<option id="nagpra_repatriation">NAGPRA repatriation</option>
+		</options>
+	</instance>
+	<instance id="vocab-objexitmethod">
+		<web-url>objexitmethod</web-url>
+		<title-ref>objexitmethod</title-ref>
+		<title>Object Exit Method</title>
+		<options>
+			<option id="auction">auction</option>
+			<option id="donation">donation</option>
+			<option id="repatriation">repatriation</option>
+			<option id="sale">sale</option>
+			<option id="shred">shred</option>
+			<option id="trash_disposal">trash disposal</option>
+		</options>
+	</instance>
+	<instance id="vocab-exitreason">
+		<web-url>objexitreason</web-url>
+		<title-ref>objexitreason</title-ref>
+		<title>Object Exit Reason</title>
+		<options>
+			<option id="deaccession">deaccession</option>
+			<option id="disposal">disposal</option>
+			<option id="repatriation">repatriation</option>
+			<option id="return_loan">return of loan</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -1480,19 +1480,6 @@
 			<option id="set">set</option>
 		</options>
 	</instance>
-	<instance id="vocab-deaccessionreason">
-		<web-url>deaccessionreason</web-url>
-		<title-ref>deaccessionreason</title-ref>
-		<title>Deaccession Reason</title>
-		<options>
-			<option id="no_longer_useful">no longer useful to the organization purpose</option>
-			<option id="does_not_fit">does not fit collecting policy</option>
-			<option id="deteriorated">has deteriorated beyond usefulness</option>
-			<option id="no_longer_preserved">can no longer be preserved</option>
-			<option id="has_better_example">is represented by a better example</option>
-			<option id="nagpra_repatriation">NAGPRA repatriation</option>
-		</options>
-	</instance>
 	<instance id="vocab-objexitmethod">
 		<web-url>objexitmethod</web-url>
 		<title-ref>objexitmethod</title-ref>

--- a/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
@@ -2064,19 +2064,6 @@
 		</options>
 	</instance>
 	<!--
-		<instance id="vocab-deaccessionreason">
-		<web-url>deaccessionreason</web-url>
-		<title-ref>deaccessionreason</title-ref>
-		<title>Deaccession Reason</title>
-		<options>
-			<option id="no_longer_useful">no longer useful to the organization purpose</option>
-			<option id="does_not_fit">does not fit collecting policy</option>
-			<option id="deteriorated">has deteriorated beyond usefulness</option>
-			<option id="no_longer_preserved">can no longer be preserved</option>
-			<option id="has_better_example">is represented by a better example</option>
-			<option id="nagpra_repatriation">NAGPRA repatriation</option>
-		</options>
-	</instance>
 	<instance id="vocab-objexitmethod">
 		<web-url>objexitmethod</web-url>
 		<title-ref>objexitmethod</title-ref>

--- a/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
@@ -2063,4 +2063,43 @@
 			<option id="set">set</option>
 		</options>
 	</instance>
+	<!--
+		<instance id="vocab-deaccessionreason">
+		<web-url>deaccessionreason</web-url>
+		<title-ref>deaccessionreason</title-ref>
+		<title>Deaccession Reason</title>
+		<options>
+			<option id="no_longer_useful">no longer useful to the organization purpose</option>
+			<option id="does_not_fit">does not fit collecting policy</option>
+			<option id="deteriorated">has deteriorated beyond usefulness</option>
+			<option id="no_longer_preserved">can no longer be preserved</option>
+			<option id="has_better_example">is represented by a better example</option>
+			<option id="nagpra_repatriation">NAGPRA repatriation</option>
+		</options>
+	</instance>
+	<instance id="vocab-objexitmethod">
+		<web-url>objexitmethod</web-url>
+		<title-ref>objexitmethod</title-ref>
+		<title>Object Exit Method</title>
+		<options>
+			<option id="auction">auction</option>
+			<option id="donation">donation</option>
+			<option id="repatriation">repatriation</option>
+			<option id="sale">sale</option>
+			<option id="shred">shred</option>
+			<option id="trash_disposal">trash disposal</option>
+		</options>
+	</instance>
+	<instance id="vocab-exitreason">
+		<web-url>objexitreason</web-url>
+		<title-ref>objexitreason</title-ref>
+		<title>Object Exit Reason</title>
+		<options>
+			<option id="deaccession">deaccession</option>
+			<option id="disposal">disposal</option>
+			<option id="repatriation">repatriation</option>
+			<option id="return_loan">return of loan</option>
+		</options>
+	</instance>
+	-->
 </instances>


### PR DESCRIPTION
**What does this do?**
* Corrects default terms for exit methods
* Corrects default terms for exit reasons
* Disambiguates new term lists from existing static lists

**Why are we doing this? (with JIRA link)**
Jira: 
* https://collectionspace.atlassian.net/browse/DRYD-1484
* https://collectionspace.atlassian.net/browse/DRYD-1481

We added two new term lists in anticipation of the new Object Exit procedure which share the same name with an existing static term list. For clarity we decided it would be best to change the names of the lists so that they are different from the existing lists.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Query for the new term lists
```
> curl -v --user admin@core.collectionspace.org:Administrator "http://localhost:8180/cspace-services/vocabularies/urn:cspace:name(objexitmethod)"
> curl -v --user admin@core.collectionspace.org:Administrator "http://localhost:8180/cspace-services/vocabularies/urn:cspace:name(objexitreason)"
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally