### PR TITLE
DRYD-1356: New ObjectExit Procedure

### DIFF
--- a/tomcat-main/src/main/resources/anthro-tenant.xml
+++ b/tomcat-main/src/main/resources/anthro-tenant.xml
@@ -38,6 +38,7 @@
 			<include src="base-procedure-summarydocumentation.xml" />
 			<include src="base-procedure-heldintrust.xml" />
 			<include src="base-procedure-consultation.xml" />
+			<include src="base-procedure-exit.xml" />
 
 			<include src="base-authority-contact.xml" />
 			<!-- IMPORTANT: *-termList.xml files MUST precede their equivalent files. -->

--- a/tomcat-main/src/main/resources/core-tenant.xml
+++ b/tomcat-main/src/main/resources/core-tenant.xml
@@ -39,6 +39,7 @@
 			<include src="base-procedure-heldintrust.xml" />
 			<include src="base-procedure-consultation.xml" />
 			<include src="base-procedure-deaccession.xml" />
+			<include src="base-procedure-exit.xml" />
 
 			<include src="base-authority-contact.xml" />
 			<!-- IMPORTANT: *-termList.xml files MUST precede their equivalent files. -->

--- a/tomcat-main/src/main/resources/default.xml
+++ b/tomcat-main/src/main/resources/default.xml
@@ -38,6 +38,7 @@
       <include src="base-procedure-heldintrust.xml" />
       <include src="base-procedure-consultation.xml" />
       <include src="base-procedure-deaccession.xml" />
+      <include src="base-procedure-exit.xml" />
 
       <include src="base-authority-contact.xml" />
       <!-- IMPORTANT: *-termList.xml files MUST precede their equivalent files. -->

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -2368,4 +2368,18 @@
 			<option id="set">set</option>
 		</options>
 	</instance>
+	<instance id="vocab-objexitagentrole">
+		<web-url>objexitagentrole</web-url>
+		<title-ref>objexitagentrole</title-ref>
+		<title>Object Exit Agent Roles</title>
+		<options>
+			<option id="purchaser">purchaser</option>
+			<option id="auction_house">auction house</option>
+			<option id="museum_coordinator">museum coordinator</option>
+			<option id="original_donor">original donor</option>
+			<option id="sale_broker">sale broker</option>
+			<option id="shredding_company">shredding company</option>
+			<option id="tribal_representative">tribal representative</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/defaults/base-procedure-exit.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-exit.xml
@@ -1,0 +1,54 @@
+<record id="exit" in-findedit="yes" type="record,procedure" cms-type="default" generate-services-schema="true" >
+  <services-url>exits</services-url>
+  <services-tenant-plural>Exits</services-tenant-plural>
+  <services-tenant-singular>Exit</services-tenant-singular>
+  <services-list-path>abstract-common-list/list-item</services-list-path>
+  <services-record-path>exits_common:http://collectionspace.org/services/exit,exits_common</services-record-path>
+  <services-record-path id="collectionspace_core">collectionspace_core:http://collectionspace.org/collectionspace_core/,collectionspace_core</services-record-path>
+
+  <include src="domain-procedure-exit.xml" strip-root="yes" />
+
+  <section id="coreInformation">
+    <include src="core-fields.xml" strip-root="yes" />
+  </section>
+
+  <section id="exitInformation">
+    <field id="exitNumber" mini="number,list" />
+    <field id="exitCountNote" />
+    <field id="exitDate" datatype="date" />
+    <field id="reason" autocomplete="true" ui-type="enum" />
+
+    <repeat id="owners">
+      <field id="owner" autocomplete="true" mini="summary,list" />
+    </repeat>
+
+    <repeat id="exitAgentGroupList/exitAgentGroup">
+      <field id="agent" autocomplete="true" />
+      <field id="role" autocomplete="true" ui-type="enum" />
+    </repeat>
+
+    <repeat id="methods">
+      <field id="method" autocomplete="true" ui-type="enum" />
+    </repeat>
+
+    <repeat id="approvalStatusGroupList/approvalStatusGroup">
+      <field id="group" autocomplete="true" ui-type="enum" />
+      <field id="individual" autocomplete="true" />
+      <field id="status" autocomplete="true" ui-type="enum" />
+      <field id="date" datatype="date" />
+      <repeat id="approvalStatusNotes">
+        <field id="approvalStatusNote" />
+      </repeat>
+    </repeat>
+  </section>
+
+  <section id="saleInformation">
+    <field id="saleCurrency" autocomplete="true" ui-type="enum" />
+    <field id="saleValue" datatype="integer" />
+    <field id="saleDate" ui-type="groupfield/structureddate" />
+    <field id="saleNumber" />
+    <field id="saleLot" />
+    <field id="saleNote" />
+  </section>
+
+</record>

--- a/tomcat-main/src/main/resources/defaults/domain-procedure-exit.xml
+++ b/tomcat-main/src/main/resources/defaults/domain-procedure-exit.xml
@@ -1,0 +1,4 @@
+<root>
+  <section id="domaindata">
+  </section>
+</root>

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -1549,4 +1549,18 @@
 			<option id="return_loan">return of loan</option>
 		</options>
 	</instance>
+	<instance id="vocab-objexitagentrole">
+		<web-url>objexitagentrole</web-url>
+		<title-ref>objexitagentrole</title-ref>
+		<title>Object Exit Agent Roles</title>
+		<options>
+			<option id="purchaser">purchaser</option>
+			<option id="auction_house">auction house</option>
+			<option id="museum_coordinator">museum coordinator</option>
+			<option id="original_donor">original donor</option>
+			<option id="sale_broker">sale broker</option>
+			<option id="shredding_company">shredding company</option>
+			<option id="tribal_representative">tribal representative</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/fcart-tenant.xml
+++ b/tomcat-main/src/main/resources/fcart-tenant.xml
@@ -34,6 +34,7 @@
 			<include src="base-procedure-transport.xml" />
 			<include src="base-procedure-conservation.xml" />
 			<include src="base-procedure-uoc.xml" />
+			<include src="base-procedure-exit.xml" />
 
 			<include src="base-authority-contact.xml" />
                         <!-- IMPORTANT: *-termList.xml files MUST precede their equivalent files. -->

--- a/tomcat-main/src/main/resources/lhmc-tenant.xml
+++ b/tomcat-main/src/main/resources/lhmc-tenant.xml
@@ -29,6 +29,7 @@
 			<include src="base-procedure-objectexit.xml" />
 			<include src="base-procedure-conservation.xml" />
 			<include src="base-procedure-uoc.xml" />
+			<include src="base-procedure-exit.xml" />
 
 			<include src="base-authority-contact.xml" />
 			<!-- IMPORTANT: *-termList.xml files MUST precede their equivalent files. -->

--- a/tomcat-main/src/main/resources/materials-tenant.xml
+++ b/tomcat-main/src/main/resources/materials-tenant.xml
@@ -27,6 +27,7 @@
 			<include src="base-procedure-movement.xml" />
 			<include src="base-procedure-objectexit.xml" />
 			<include src="base-procedure-uoc.xml" />
+			<include src="base-procedure-exit.xml" />
 
 			<include src="base-authority-contact.xml" />
 			<!-- IMPORTANT: *-termList.xml files MUST precede their equivalent files. -->

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
@@ -2033,5 +2033,20 @@
 			<option id="return_loan">return of loan</option>
 		</options>
 	</instance>
+	<instance id="vocab-objexitagentrole">
+		<web-url>objexitagentrole</web-url>
+		<title-ref>objexitagentrole</title-ref>
+		<title>Object Exit Agent Roles</title>
+		<options>
+			<option id="purchaser">purchaser</option>
+			<option id="auction_house">auction house</option>
+			<option id="museum_coordinator">museum coordinator</option>
+			<option id="original_donor">original donor</option>
+			<option id="sale_broker">sale broker</option>
+			<option id="shredding_company">shredding company</option>
+			<option id="tribal_representative">tribal representative</option>
+		</options>
+	</instance>
+
 	-->
 </instances>

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -1504,4 +1504,18 @@
 			<option id="return_loan">return of loan</option>
 		</options>
 	</instance>
+	<instance id="vocab-objexitagentrole">
+		<web-url>objexitagentrole</web-url>
+		<title-ref>objexitagentrole</title-ref>
+		<title>Object Exit Agent Roles</title>
+		<options>
+			<option id="purchaser">purchaser</option>
+			<option id="auction_house">auction house</option>
+			<option id="museum_coordinator">museum coordinator</option>
+			<option id="original_donor">original donor</option>
+			<option id="sale_broker">sale broker</option>
+			<option id="shredding_company">shredding company</option>
+			<option id="tribal_representative">tribal representative</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
@@ -2088,5 +2088,19 @@
 			<option id="return_loan">return of loan</option>
 		</options>
 	</instance>
+	<instance id="vocab-objexitagentrole">
+		<web-url>objexitagentrole</web-url>
+		<title-ref>objexitagentrole</title-ref>
+		<title>Object Exit Agent Roles</title>
+		<options>
+			<option id="purchaser">purchaser</option>
+			<option id="auction_house">auction house</option>
+			<option id="museum_coordinator">museum coordinator</option>
+			<option id="original_donor">original donor</option>
+			<option id="sale_broker">sale broker</option>
+			<option id="shredding_company">shredding company</option>
+			<option id="tribal_representative">tribal representative</option>
+		</options>
+	</instance>
 	-->
 </instances>


### PR DESCRIPTION
**What does this do?**
* Add exit procedure definition
* Add exit agent term list
* Add new exit procedure to required profiles

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1356

The existing Object Exit procedure is being deprecated in favor of it being split into two procedures - the Deaccession and Object Exit. This handles the creation of a new Object Exit, named Exit, which will replace existing use.

**How should this be tested? Do these changes have associated tests?**
* Pull the related services PR
* Rebuild and deploy collectionspace with the required tenants enabled for running the integration tests
* Start collectionspace and verify the endpoint is accessible
```
curl --user admin@core.collectionspace.org:Administrator "http://localhost:8180/cspace-services/exits"
``` 
* Run the integration tests, e.g.
```
sdk use java 8.0.362-amzn
source ~/.config/cspace/env
cd ~/cspace/services
mvn test
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance