### PR TITLE
DRYD-1559: Update Object Count Term List

### DIFF
--- a/tomcat-main/src/main/resources/anthro-tenant.xml
+++ b/tomcat-main/src/main/resources/anthro-tenant.xml
@@ -62,7 +62,7 @@
 			<include src="base-authority-chronology-termList.xml" />
 			<include src="base-authority-chronology.xml,anthro-authority-chronology.xml" merge="xmlmerge.properties" />
 
-			<include src="base-vocabularies.xml" />
+			<include src="base-vocabularies.xml,extensions/anthro-profile-vocabularies.xml" merge="xmlmerge.properties" />
 
 			<include src="base-authz-accountrole.xml" />
 			<include src="base-authz-permission.xml" />

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -2053,8 +2053,6 @@
 		<options>
 			<option id="collection_count">collection count</option>
 			<option id="inventory_count">inventory count</option>
-			<option id="associated_funerary_objects">associated funerary objects</option>
-			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
 		</options>
 	</instance>
 	<instance id="vocab-assocauthorityrelationtype">

--- a/tomcat-main/src/main/resources/defaults/extensions/anthro-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/anthro-profile-instance-vocabularies.xml
@@ -1,0 +1,16 @@
+<!-- vocabulary overrides for the anthropology profile -->
+<instances>
+	<instance id="vocab-objectcounttypes">
+		<web-url>objectcounttypes</web-url>
+		<title-ref>objectcounttypes</title-ref>
+		<title>Object Count Types</title>
+		<options>
+			<option id="collection_count">collection count</option>
+			<option id="associated_funerary_objects">associated funerary objects</option>
+			<option id="minimum_number_of_individuals">minimum number of individuals</option>
+			<option id="objects_of_cultural_patrimony">objects of cultural patrimony</option>
+			<option id="sacred_objects">sacred objects</option>
+			<option id="unassociated_funerary_objects">unassociated funerary objects</option>
+		</options>
+	</instance>
+</instances>

--- a/tomcat-main/src/main/resources/defaults/extensions/anthro-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/anthro-profile-instance-vocabularies.xml
@@ -1,5 +1,11 @@
-<!-- vocabulary overrides for the anthropology profile -->
 <instances>
+	<!--
+	The instances tag is set to be replaced by xmlmerge so reimport the base + domain vocabularies.
+	Otherwise they would need to be added manually.
+	-->
+	<include src="domain-instance-vocabularies.xml" strip-root="yes" />
+	<include src="base-instance-vocabularies.xml" strip-root="yes" />
+	<!-- vocabulary overrides for the anthropology profile -->
 	<instance id="vocab-objectcounttypes">
 		<web-url>objectcounttypes</web-url>
 		<title-ref>objectcounttypes</title-ref>

--- a/tomcat-main/src/main/resources/defaults/extensions/anthro-profile-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/anthro-profile-vocabularies.xml
@@ -1,0 +1,3 @@
+<record id="vocab">
+	<include id="instances" src="extensions/anthro-profile-instance-vocabularies.xml" />
+</record>

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -1489,8 +1489,6 @@
 		<options>
 			<option id="collection_count">collection count</option>
 			<option id="inventory_count">inventory count</option>
-			<option id="associated_funerary_objects">associated funerary objects</option>
-			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
 		</options>
 	</instance>
 	<instance id="vocab-assocauthorityrelationtype">

--- a/tomcat-main/src/main/resources/tenants/anthro/domain-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/domain-instance-vocabularies.xml
@@ -99,23 +99,4 @@
 			<option id="adult_76_100">adult 76-100%</option>
 		</options>
 	</instance>
-
-	<instance id="vocab-anthroassertionnames">
-		<web-url>anthroassertionnames</web-url>
-		<title-ref>anthroassertionnames</title-ref>
-		<title>Assertion Names</title>
-		<options>
-			<option id="anthroassertionnames01">Geographic/territorial evidence</option>
-			<option id="anthroassertionnames02">Kinship evidence</option>
-			<option id="anthroassertionnames03">Biological evidence</option>
-			<option id="anthroassertionnames04">Archaeological evidence</option>
-			<option id="anthroassertionnames05">Anthropological evidence</option>
-			<option id="anthroassertionnames06">Linguistic evidence</option>
-			<option id="anthroassertionnames07">Folklore evidence</option>
-			<option id="anthroassertionnames08">Oral tradition</option>
-			<option id="anthroassertionnames09">Historical evidence</option>
-			<option id="anthroassertionnames10">Other relevant information or expert opinion</option>
-			<option id="anthroassertionnames11">Consultation summary</option>
-		</options>
-	</instance>
 </root>

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
@@ -1973,8 +1973,6 @@
 		<options>
 			<option id="collection_count">collection count</option>
 			<option id="inventory_count">inventory count</option>
-			<option id="associated_funerary_objects">associated funerary objects</option>
-			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
 		</options>
 	</instance>
 	<instance id="vocab-assocauthorityrelationtype">

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -1442,8 +1442,6 @@
 		<options>
 			<option id="collection_count">collection count</option>
 			<option id="inventory_count">inventory count</option>
-			<option id="associated_funerary_objects">associated funerary objects</option>
-			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
 		</options>
 	</instance>
 	<!--

--- a/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
@@ -2025,8 +2025,6 @@
 		<options>
 			<option id="collection_count">collection count</option>
 			<option id="inventory_count">inventory count</option>
-			<option id="associated_funerary_objects">associated funerary objects</option>
-			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
 		</options>
 	</instance>
 	<!--


### PR DESCRIPTION
**What does this do?**
* Updates default terms for objectcounttype
* Add anthro overrides for objectcounttype
* Remove anthroassertionnames

**Why are we doing this? (with JIRA link)**
Jira:
* https://collectionspace.atlassian.net/browse/DRYD-1433
* https://collectionspace.atlassian.net/browse/DRYD-1559

This fixes the default terms for the Object Count Type term list as per DRYD-1559. The terms in anthro were also requested to be different from those in core, which has been accomplished in a similar manner to how the fcart vocabularies are handled. The difference being that instead of copying the terms over, we reimport them in `anthro-profile-instance-vocabularies.xml`. This is done because the `<instances />` tag is set to be replaced in the xmlmerge properties, but we only want to override a single vocabulary term. 

**How should this be tested? Do these changes have associated tests?**
* Build collectionspace with anthro enabled and keep track of the original term list created, e.g.
```
...build steps
[~] $ cd $CSPACE_JEESERVER_HOME
[tomcat] $ cp ./cspace/config/services/tenants/anthro-tenant.terms.json /tmp/terms/orig/anthro-tenant.terms.json
```
* Pull the PR and rebuild collectionspace with anthro enabled as a tenant
* Verify that anthro term lists are being created/populated as expected
  * I did this with a mix of jq and jsondiff (jd could be used if doing all through cli)
```
[~] $ cd $CSPACE_JEESERVER_HOME
[tomcat] $ cp ./cspace/config/services/tenants/anthro-tenant.terms.json /tmp/terms/1559/anthro-tenant.terms.json
[tomcat] $ cd /tmp/terms
[terms] $ jq '.vocabularies | keys' ./orig/anthro-tenant.terms.json > orig-keys.json
[terms] $ jq '.vocabularies | keys' ./1559/anthro-tenant.terms.json > updated-keys.json
[terms] $ diff orig-keys.json updated-keys.json
```

**Dependencies for merging? Releasing to production?**
Although I tested the output from the build, the whole build + startup process really should be tested as well. I'm currently doing this to double check that there are no missing term lists when running the profile locally. 

**Has the application documentation been updated for these changes?**
In place notes exist in the `anthro-profile-instance-vocabularies.xml` for the updates. I'm not sure if we have developer docs on this sort of thing but it might be good to start on.

**Did someone actually run this code to verify it works?**
@mikejritter tested the generated output, is currently testing the terms get persisted to the db properly