### PR TITLE
DRYD-1474: added term 'partially approved' to deaccessionapprovalstatus

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -318,7 +318,6 @@
 			<option id="publisher">Publisher</option>
 		</options>
 	</instance>
-
 	<instance id="vocab-citationtermtype">
 		<web-url>citationtermtype</web-url>
 		<title-ref>citationtermtype</title-ref>
@@ -1192,6 +1191,7 @@
 			<option id="consulted">consulted</option>
 			<option id="deed_returned">deed returned</option>
 			<option id="deed_sent">deed sent</option>
+			<option id="partially_approved">partially approved</option>
 			<option id="tabled">tabled</option>
 			<option id="under_arbitration">under arbitration</option>
 		</options>

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -647,6 +647,7 @@
 			<option id="consulted">consulted</option>
 			<option id="deed_returned">deed returned</option>
 			<option id="deed_sent">deed sent</option>
+			<option id="partially_approved">partially approved</option>
 			<option id="tabled">tabled</option>
 			<option id="under_arbitration">under arbitration</option>
 		</options>

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
@@ -1192,6 +1192,7 @@
 			<option id="consulted">consulted</option>
 			<option id="deed_returned">deed returned</option>
 			<option id="deed_sent">deed sent</option>
+			<option id="partially_approved">partially approved</option>
 			<option id="tabled">tabled</option>
 			<option id="under_arbitration">under arbitration</option>
 		</options>

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -1209,6 +1209,7 @@
 			<option id="consulted">consulted</option>
 			<option id="deed_returned">deed returned</option>
 			<option id="deed_sent">deed sent</option>
+			<option id="partially_approved">partially approved</option>
 			<option id="tabled">tabled</option>
 			<option id="under_arbitration">under arbitration</option>
 		</options>

--- a/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
@@ -1192,6 +1192,7 @@
 			<option id="consulted">consulted</option>
 			<option id="deed_returned">deed returned</option>
 			<option id="deed_sent">deed sent</option>
+			<option id="partially_approved">partially approved</option>
 			<option id="tabled">tabled</option>
 			<option id="under_arbitration">under arbitration</option>
 		</options>


### PR DESCRIPTION
**What does this do?**
Update default terms in deaccessionapprovalstatus (Approval Status) term list to include the option "partially approved"  

**Why are we doing this? (with JIRA link)**
Jira ticket: https://collectionspace.atlassian.net/browse/DRYD-1474

**How should this be tested? Do these changes have associated tests?**
- Re-build and deploy collectionspace
- Start collectionspace
- Create New -> Procedures -> Deaccession
- Under Deaccession approval, see Status pulldown has new option "partially approved" (see attached screenshot)

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@axb21 tested as per above procedure (see screenshot)

**Screenshot
![image](https://github.com/user-attachments/assets/d1cff3d3-4b61-4668-9096-18f5ea94836c)
