### PR TITLE
DRYD-1595: Add legacy tag to procedures

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-procedure-claim.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-claim.xml
@@ -1,4 +1,4 @@
-<record id="claim" in-findedit="yes" type="record,procedure" cms-type="default" generate-services-schema="true">
+<record id="claim" in-findedit="yes" type="record,procedure" tag="legacy" cms-type="default" generate-services-schema="true">
 	<services-url>claims</services-url>
 	<services-tenant-singular>Claim</services-tenant-singular>
 	<services-tenant-plural>Claims</services-tenant-plural>

--- a/tomcat-main/src/main/resources/defaults/base-procedure-objectexit.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-objectexit.xml
@@ -1,4 +1,4 @@
-<record id="objectexit" in-findedit="yes" type="record,procedure" cms-type="default" generate-services-schema="true">
+<record id="objectexit" in-findedit="yes" type="record,procedure" tag="legacy" cms-type="default" generate-services-schema="true">
 	<!-- Added this tag because services path is currently singular for Object Exit. -->
 	<services-url>objectexit</services-url>
 	<services-tenant-plural>ObjectExit</services-tenant-plural>

--- a/tomcat-main/src/main/resources/defaults/base-procedure-osteology.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-osteology.xml
@@ -1,4 +1,4 @@
-<record id="osteology" in-findedit="yes" type="record,procedure" cms-type="default" generate-services-schema="true">
+<record id="osteology" in-findedit="yes" type="record,procedure" tag="legacy" cms-type="default" generate-services-schema="true">
     <services-url>osteology</services-url>
     <services-tenant-plural>Osteology</services-tenant-plural>
     <services-tenant-singular>Osteology</services-tenant-singular>


### PR DESCRIPTION
**What does this do?**
* Add legacy tag to ObjectExit, Osteology, and Claim

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1595

As part of the updates to the Create Page and new procedures for 8.1, we want to let users know that certain procedures will be considered legacy and should not be preferred. Since we handled the NAGPRA procedures by adding a tag attr to the xml, we've done the same here by adding the tag attr to Object Exit, Osteology, and Claim.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace
* Query for legacy procedures, e.g.
```
curl -H "Accept: application/json" -v --user admin@core.collectionspace.org:Administrator "http://localhost:8180/cspace-services/servicegroups/procedure?servicetag=legacy"
```
* Note that if you want to see claim in the response, it needs to be done on the anthro profile

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance