### PR TITLE
DRYD-1553: added deaccession procedure include to anthro, fcart, lhmc and materials tenant configurations

### DIFF
--- a/tomcat-main/src/main/resources/anthro-tenant.xml
+++ b/tomcat-main/src/main/resources/anthro-tenant.xml
@@ -41,6 +41,7 @@
 			<include src="base-procedure-consultation.xml" />
 			<include src="base-procedure-restrictedmedia.xml" />
 			<include src="base-procedure-exit.xml" />
+			<include src="base-procedure-deaccession.xml" />
 
 			<include src="base-authority-contact.xml" />
 			<!-- IMPORTANT: *-termList.xml files MUST precede their equivalent files. -->

--- a/tomcat-main/src/main/resources/fcart-tenant.xml
+++ b/tomcat-main/src/main/resources/fcart-tenant.xml
@@ -35,6 +35,7 @@
 			<include src="base-procedure-conservation.xml" />
 			<include src="base-procedure-uoc.xml" />
 			<include src="base-procedure-exit.xml" />
+			<include src="base-procedure-deaccession.xml" />
 
 			<include src="base-authority-contact.xml" />
                         <!-- IMPORTANT: *-termList.xml files MUST precede their equivalent files. -->

--- a/tomcat-main/src/main/resources/lhmc-tenant.xml
+++ b/tomcat-main/src/main/resources/lhmc-tenant.xml
@@ -31,6 +31,7 @@
 			<include src="base-procedure-conservation.xml" />
 			<include src="base-procedure-uoc.xml" />
 			<include src="base-procedure-exit.xml" />
+			<include src="base-procedure-deaccession.xml" />
 
 			<include src="base-authority-contact.xml" />
 			<!-- IMPORTANT: *-termList.xml files MUST precede their equivalent files. -->

--- a/tomcat-main/src/main/resources/materials-tenant.xml
+++ b/tomcat-main/src/main/resources/materials-tenant.xml
@@ -28,6 +28,7 @@
 			<include src="base-procedure-objectexit.xml" />
 			<include src="base-procedure-uoc.xml" />
 			<include src="base-procedure-exit.xml" />
+			<include src="base-procedure-deaccession.xml" />
 
 			<include src="base-authority-contact.xml" />
 			<!-- IMPORTANT: *-termList.xml files MUST precede their equivalent files. -->


### PR DESCRIPTION
**What does this do?**
The Deaccession procedure is now available in the anthro, fcart, lhmc, and materials profiles.

**Why are we doing this? (with JIRA link)**
JIRA ticket DRYD-1553, https://collectionspace.atlassian.net/browse/DRYD-1553

**How should this be tested? Do these changes have associated tests?**
- Pull this commit
- Stop CSpace, re-deploy, start CSpace
- For each of the anthro, fcart, lhmc, and materials UI plugins:
   - Launch the plugin (`npm run devserver` in the plugin's directory)
   - Login to the profile
   - Click Create New
   - See "Deaccession" listed in the available procedures
   - Click "Deaccession" and see that the expected page is shown

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes, @axb21 ran through the above procedure locally.