### PR TITLE
Add lineal descendant to object count types

### DIFF
--- a/tomcat-main/src/main/resources/defaults/extensions/anthro-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/anthro-profile-instance-vocabularies.xml
@@ -18,6 +18,7 @@
 			<option id="sacred_objects">sacred objects</option>
 			<option id="unassociated_funerary_objects">unassociated funerary objects</option>
 			<option id="ethnographic_objects">ethnographic objects</option>
+			<option id="lineal_descendant">lineal descendant</option>
 		</options>
 	</instance>
 </instances>


### PR DESCRIPTION
**What does this do?**
* Adds lineal descendant to object count types

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1514

Lineal descendant is used in the repatriation request consultation report, but was previously unable to be populated because the term did not exist. This adds the term to the object count types list.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace with anthro enabled
* Query using the anthro admin for objectcounttypes and see lineal descendant

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
No
