### PR TITLE
Remove legacy tag from osteology

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-procedure-osteology.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-osteology.xml
@@ -1,4 +1,4 @@
-<record id="osteology" in-findedit="yes" type="record,procedure" tag="legacy" cms-type="default" generate-services-schema="true">
+<record id="osteology" in-findedit="yes" type="record,procedure" cms-type="default" generate-services-schema="true">
     <services-url>osteology</services-url>
     <services-tenant-plural>Osteology</services-tenant-plural>
     <services-tenant-singular>Osteology</services-tenant-singular>


### PR DESCRIPTION
**What does this do?**
* Remove the legacy tag from osteology

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1595

Although osteology is not as good as it could be, it is not ready to be marked as legacy. This undoes the original changes from DRYD-1595.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* See that osteology does not have the legacy tag in profiles where it is used

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally