### PR TITLE
Set ui-type for reason

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-procedure-consultation.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-consultation.xml
@@ -15,7 +15,7 @@
   <section id="consultationInformation">
     <field id="consultationNumber" mini="number,list" />
     <field id="consultationDate" datatype="date" />
-    <field id="reason" autocomplete="true" />
+    <field id="reason" autocomplete="true" ui-type="enum" />
     <repeat id="notes">
       <field id="note" />
     </repeat>


### PR DESCRIPTION
**What does this do?**
* Set ui-type for reason field

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1618

We noticed in our regression testing that consultations were throwing an error related to the `consultationreason`. This was actually from the `reason` field showing up in the related terms even though it is not an authority. The fix for this is to set `ui-type="enum"` so that when the service bindings are being generated the `authRef` property is not included on the field.

**How should this be tested? Do these changes have associated tests?**
* Start collectionspace
* Create a Consultation with a consultation reason
* On save, notice the `Terms Used` panel will have a single result
  * If the panel is expanded you'll get an exception, which is ok. You can instead use the api, e.g.
```
curl --user 'user:pass' http://localhost:8180/cspace-services/consultations/07ec9e16-1280-4c56-a7af/authorityrefs
```
* Stop collectionspace
* Rebuild and restart collectionspace
* Go back to the consultation you created and see that the `Terms Used` panel has no results and can be expanded/collapsed.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local install
