### PR TITLE
DRYD-1624: Add deaccession and object exit to publicart

### DIFF
--- a/tomcat-main/src/main/resources/publicart-tenant.xml
+++ b/tomcat-main/src/main/resources/publicart-tenant.xml
@@ -26,6 +26,8 @@
 			<include src="base-procedure-movement.xml" />
 			<include src="base-procedure-objectexit.xml" />
 			<include src="base-procedure-conservation.xml,publicart-procedure-conservation.xml" merge="xmlmerge.properties" />
+			<include src="base-procedure-exit.xml" />
+			<include src="base-procedure-deaccession.xml" />
 
 			<include src="base-authority-contact.xml" />
 			<include src="base-authority-location-termList.xml" />
@@ -64,10 +66,10 @@
 			<include src="base-other-termlistitem.xml" />
 			<include src="base-other-reporting.xml" />
 			<include src="base-other-reportingoutput.xml" />
-		    <include src="base-other-batch.xml" />
-		    <include src="base-other-batchoutput.xml" />
-		    <include src="base-other-invocationresults.xml" />
-		    <include src="base-other-searchall.xml" />
+			<include src="base-other-batch.xml" />
+			<include src="base-other-batchoutput.xml" />
+			<include src="base-other-invocationresults.xml" />
+			<include src="base-other-searchall.xml" />
 			<include src="base-other-associatedauthority.xml" />
 		</records>
 	</spec>

--- a/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
@@ -2062,7 +2062,19 @@
 			<option id="set">set</option>
 		</options>
 	</instance>
-	<!--
+	<instance id="vocab-deaccessionreason">
+		<web-url>deaccessionreason</web-url>
+		<title-ref>deaccessionreason</title-ref>
+		<title>Deaccession Reason</title>
+		<options>
+			<option id="no_longer_useful">no longer useful to the organization purpose</option>
+			<option id="does_not_fit">does not fit collecting policy</option>
+			<option id="deteriorated">has deteriorated beyond usefulness</option>
+			<option id="no_longer_preserved">can no longer be preserved</option>
+			<option id="has_better_example">is represented by a better example</option>
+			<option id="nagpra_repatriation">NAGPRA repatriation</option>
+		</options>
+	</instance>
 	<instance id="vocab-objexitmethod">
 		<web-url>objexitmethod</web-url>
 		<title-ref>objexitmethod</title-ref>
@@ -2101,5 +2113,4 @@
 			<option id="tribal_representative">tribal representative</option>
 		</options>
 	</instance>
-	-->
 </instances>


### PR DESCRIPTION
**What does this do?**
* Add new deaccession and object exit procedures to publicart profile

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1624

These were initially missed during the 8.1 release and are being added to the publicart profile.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace with the publicart tenant enabled
* Check that both procedures are now able to be queried for
```
curl --user admin@publicart.collectionspace.org:Administrator http://localhost:8180/cspace-services/deaccessions
curl --user admin@publicart.collectionspace.org:Administrator http://localhost:8180/cspace-services/exits
```

**Dependencies for merging? Releasing to production?**
Needs verification in the publicart ui profile as well.

**Has the application documentation been updated for these changes?**
Nope

**Did someone actually run this code to verify it works?**
Probably not