### PR TITLE
DRYD-1625: Remove objectexit service tag in botgarden 

### DIFF
--- a/tomcat-main/src/main/resources/tenants/botgarden/botgarden-procedure-objectexit.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/botgarden-procedure-objectexit.xml
@@ -1,4 +1,4 @@
-<record id="objectexit">
+<record id="objectexit" tag="">
 	<section id="objectexitInformation">
 		<!-- Remove summary from mini -->
 		<field id="currentOwner" mini="" />


### PR DESCRIPTION
**What does this do?**
* Remove the service tag for object exit in botgarden

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1625

The botgarden tenant renames object exit and as such it shouldn't be marked as deprecated. 

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace with the botgarden tenant enabled
* Check the servicegroups endpoint to see if object exit is included in the 'legacy' tags
```
curl --user admin@botgarden.collectionspace.org:Administrator "http://localhost:8180/cspace-services/servicegroups/procedure?servicetag=legacy" -H "Accept: application/json" | jq .
```

**Dependencies for merging? Releasing to production?**
Not a dependency but honestly it's confusing to rename a procedure entirely. It might be worth looking into creating a separate procedure for botgarden which could be used in place of overriding object exit.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally