### PR TITLE
DRYD-1797: Add note field to 8.1 procedures

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-procedure-exit.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-exit.xml
@@ -40,6 +40,8 @@
         <field id="approvalStatusNote" />
       </repeat>
     </repeat>
+
+    <field id="note" />
   </section>
 
   <section id="saleInformation">

--- a/tomcat-main/src/main/resources/defaults/base-procedure-heldintrust.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-heldintrust.xml
@@ -44,6 +44,8 @@
       <field id="correspondenceDate" datatype="date" />
       <field id="correspondenceSummary" />
     </repeat>
+
+    <field id="note" />
   </section>
 
   <section id="culturalCareInformation">

--- a/tomcat-main/src/main/resources/defaults/base-procedure-nagprainventory.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-nagprainventory.xml
@@ -51,6 +51,8 @@
       <field id="inventoryDate" datatype="date" />
       <field id="inventoryNote" />
     </repeat>
+
+    <field id="note" />
   </section>
 
   <section id="inventoryContextInformation">

--- a/tomcat-main/src/main/resources/defaults/base-procedure-summarydocumentation.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-summarydocumentation.xml
@@ -55,6 +55,8 @@
       <field id="statusDate" datatype="date" />
       <field id="statusNote" />
     </repeat>
+
+    <field id="note" />
   </section>
 
   <section id="summaryDocumentationContext">


### PR DESCRIPTION
**What does this do?**
Adds a freetext `note` field to
* Held-in-Trust
* Object Exit (new)
* NAGPRA Inventory
* SummaryDocumentation

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1797

A few of the new procedures were missing a general purpose note field. 

**How should this be tested? Do these changes have associated tests?**
* Build and deploy collectionspace
* Check that the exits_common, heldintrusts_common, nagprainventories_common, and summarydocumentations_common tables all contain a note row

**Dependencies for merging? Releasing to production?**
Some of these might want to be repeatable. Need to check first before merging.

**Has the application documentation been updated for these changes?**
No. A CHANGELOG or README should be added as part of this pull request.

**Did someone actually run this code to verify it works?**
@mikejritter tested locally