### PR TITLE
DRYD-1770: Add production agent

### DIFF
--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -346,6 +346,9 @@
 			<field id="objectProductionOrganization" autocomplete="true" />
 			<field id="objectProductionOrganizationRole" />
 		</repeat>
+		<repeat id="objectProductionAgents">
+			<field id="objectProductionAgent" />
+		</repeat>
 		<field id="objectProductionNote" />
 	</section>
 	<section id="objectHistoryAssociationInformation">


### PR DESCRIPTION
**What does this do?**
This adds a repeating field `objectProductionAgent` to the base collectionobject schema.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1770

This was requested to be added complement the authority-controlled field which will ease pre-migration data clean-up tasks when an institution chooses to address authority in post-migration tasks

**How should this be tested? Do these changes have associated tests?**
* Rebuild and deploy collectionspace
* Connect to the `nuxeo_default` database
* See the table `collectionobjects_common_objectproductionagents` exists

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter is in the process of testing locally