### PR TITLE
DRYD-1744: Remove anthroOwnershipAccess

### DIFF
--- a/tomcat-main/src/main/resources/tenants/anthro/anthro-collectionobject.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/anthro-collectionobject.xml
@@ -73,7 +73,6 @@
 	<section id="objectHistoryAssociationInformation">
 		<repeat id="anthroOwnershipGroupList/anthroOwnershipGroup" section="anthro">
 			<field id="anthroOwner" section="anthro" autocomplete="true" />
-			<field id="anthroOwnershipAccess" section="anthro" />
 
 			<group id="anthroOwnershipDateGroup" section="anthro" ui-type="groupfield/structureddate" />
 


### PR DESCRIPTION
**What does this do?**
This removes `anthroOwnershipAccess` from the anthro-collectionobject schema

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1744

This field was originally added with the `anthroOwnershipGroup` but was never added to the ui. We're opting to remove it since we haven't heard any requests for it.

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start collectionspace
* See that `anthroownershipaccess` does not exist in the `anthroownershipgroup` table

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
No