### PR TITLE
Add support for authority display names

### DIFF
--- a/cspi-installation/src/main/java/org/collectionspace/chain/installation/ServiceBindingsGeneration.java
+++ b/cspi-installation/src/main/java/org/collectionspace/chain/installation/ServiceBindingsGeneration.java
@@ -716,7 +716,6 @@ public class ServiceBindingsGeneration {
      * @param thisns
      * @param isAuthority
      */
-
 	private void doDocHandlerParams(Record r, Element el, Namespace nsservices2, Boolean isAuthority) {
 		//<service:DocHandlerParams>
 		Element dhele = el.addElement(new QName("DocHandlerParams", nsservices2));
@@ -902,6 +901,7 @@ public class ServiceBindingsGeneration {
 		bindingsForAuthority.addAttribute("id", r.getServicesTenantAuthPl());
 		bindingsForAuthority.addAttribute("type", RECORD_TYPE_UTILITY);
 		bindingsForAuthority.addAttribute("version", serviceBindingVersion);
+		bindingsForAuthority.addAttribute("displayName", r.getServicesTenantAuthDisplayName());
 		bindingsForAuthority.addAttribute(Record.SUPPORTS_REPLICATING, Boolean.toString(r.supportsReplicating()));
 		bindingsForAuthority.addAttribute(Record.REQUIRES_UNIQUE_SHORTID, Boolean.TRUE.toString());
 		String remoteClientConfigName = r.getRemoteClientConfigName();
@@ -952,7 +952,7 @@ public class ServiceBindingsGeneration {
 			doDocHandlerParams(r, el, this.nsservices, isAuthority);
 
 			//<service:AuthorityInstanceList>
-			if (isAuthority == true || r.isType(RECORD_TYPE_VOCABULARY) == true) {
+			if (isAuthority || r.isType(RECORD_TYPE_VOCABULARY)) {
 				doAuthorityInstanceList(r, el, this.nsservices);
 			}
 

--- a/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/Record.java
+++ b/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/Record.java
@@ -38,6 +38,8 @@ public class Record implements FieldParent {
 	private static final String TYPE_AUTHORITY = "Authority";
 	private static final String TYPE_AUTHORITY_LOWERCASE = TYPE_AUTHORITY.toLowerCase();
 
+	public static final String AUTH_DISPLAY_NAME = "services-tenant-auth-display-name";
+
 	public static final String ELASTICSEARCH_INDEXED = "elasticsearchIndexed";
 	public static final String SUPPORTS_LOCKING = "supportslocking";
 	public static final String SUPPORTS_REPLICATING = "supportsReplicating";
@@ -257,6 +259,7 @@ public class Record implements FieldParent {
 		utils.initStrings(section, "services-tenant-plural", utils.getString("services-tenant-singular") + "s");
 		utils.initStrings(section, "services-tenant-auth-singular", utils.getString("services-url"));
 		utils.initStrings(section, "services-tenant-auth-plural", utils.getString("services-tenant-singular") + "s");
+		utils.initStrings(section, AUTH_DISPLAY_NAME, utils.getString("services-tenant-singular"));
 
 		utils.initStrings(section, "services-schema-location", "http://services.collectionspace.org");
 
@@ -825,6 +828,10 @@ public class Record implements FieldParent {
 
 	public String getServicesTenantAuthSg() {
 		return utils.getString("services-tenant-auth-singular");
+	}
+
+	public String getServicesTenantAuthDisplayName() {
+		return utils.getString(AUTH_DISPLAY_NAME);
 	}
 
 	/*
@@ -1442,4 +1449,5 @@ public class Record implements FieldParent {
 	public String getSortKey(String fieldId) {
 		return sortKeys.get(fieldId);
 	}
+
 }

--- a/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
@@ -4,6 +4,7 @@
 
   <services-tenant-auth-plural>Chronologyauthorities</services-tenant-auth-plural>
   <services-tenant-auth-singular>Chronologyauthority</services-tenant-auth-singular>
+	<services-tenant-auth-display-name>Chronology</services-tenant-auth-display-name>
   <services-tenant-singular>Chronology</services-tenant-singular>
   <services-tenant-plural>Chronologies</services-tenant-plural>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
@@ -31,12 +31,12 @@
     <instance id="chronology-era">
       <web-url>era</web-url>
       <title-ref>era</title-ref>
-      <title>Era Chronologies</title>
+      <title>Era</title>
     </instance>
     <instance id="chronology-event">
       <web-url>event</web-url>
       <title-ref>event</title-ref>
-      <title>Event Chronologies</title>
+      <title>Event</title>
     </instance>
   </instances>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-citation.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-citation.xml
@@ -5,6 +5,7 @@
 
 	<services-tenant-auth-singular>Citationauthority</services-tenant-auth-singular>
 	<services-tenant-auth-plural>Citationauthorities</services-tenant-auth-plural>
+	<services-tenant-auth-display-name>Citation</services-tenant-auth-display-name>
 	<services-tenant-singular>Citation</services-tenant-singular>
 
 	<services-instances-path>citationauthorities_common:http://collectionspace.org/services/citation,abstract-common-list/list-item</services-instances-path>

--- a/tomcat-main/src/main/resources/defaults/base-authority-citation.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-citation.xml
@@ -30,12 +30,12 @@
 		<instance id="citation-citation">
 			<web-url>citation</web-url>
 			<title-ref>citation</title-ref>
-			<title>Local Citations</title>
+			<title>Local</title>
 		</instance>
 		<instance id="citation-worldcat">
 			<web-url>worldcat</web-url>
 			<title-ref>worldcat</title-ref>
-			<title>WorldCat Citations</title>
+			<title>WorldCat</title>
 		</instance>
 	</instances>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-concept.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-concept.xml
@@ -4,6 +4,7 @@
 
 	<services-tenant-auth-singular>Conceptauthority</services-tenant-auth-singular>
 	<services-tenant-auth-plural>Conceptauthorities</services-tenant-auth-plural>
+	<services-tenant-auth-display-name>Concept</services-tenant-auth-display-name>
 	<services-tenant-singular>Concept</services-tenant-singular>
 	<services-tenant-doctype>Conceptitem</services-tenant-doctype>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-concept.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-concept.xml
@@ -76,7 +76,7 @@
 		<instance id="concept-archculture">
 			<web-url>archculture</web-url>
 			<title-ref>archculture</title-ref>
-			<title>Archaeological Cultures</title>
+			<title>Archaeological Culture</title>
 		</instance>
 	</instances>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-concept.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-concept.xml
@@ -33,17 +33,17 @@
 		<instance id="concept-concept">
 			<web-url>concept</web-url>
 			<title-ref>concept</title-ref>
-			<title>Associated Concepts</title>
+			<title>Associated</title>
 		</instance>
 		<instance id="concept-material_ca">
 			<web-url>material_ca</web-url>
 			<title-ref>material_ca</title-ref>
-			<title>Material Concepts</title>
+			<title>Material</title>
 		</instance>
 		<instance id="concept-activity">
 			<web-url>activity</web-url>
 			<title-ref>activity</title-ref>
-			<title>Activity Concepts</title>
+			<title>Activity</title>
 		</instance>
 		<instance id="concept-nomenclature">
 			<web-url>nomenclature</web-url>
@@ -65,13 +65,13 @@
 		<instance id="concept-occasion">
 			<web-url>occasion</web-url>
 			<title-ref>occasion</title-ref>
-			<title>Occasion Concepts</title>
+			<title>Occasion</title>
 		</instance>
 		<!-- NAGPRA Culture fields -->
 		<instance id="concept-ethculture">
 			<web-url>ethculture</web-url>
 			<title-ref>ethculture</title-ref>
-			<title>Ethnographic Cultures</title>
+			<title>Cultural Group</title>
 		</instance>
 		<instance id="concept-archculture">
 			<web-url>archculture</web-url>

--- a/tomcat-main/src/main/resources/defaults/base-authority-location.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-location.xml
@@ -4,7 +4,7 @@
 
 	<services-tenant-auth-singular>Locationauthority</services-tenant-auth-singular>
 	<services-tenant-auth-plural>Locationauthorities</services-tenant-auth-plural>
-  <services-tenant-auth-display-name>Storage Location</services-tenant-auth-display-name>
+	<services-tenant-auth-display-name>Storage Location</services-tenant-auth-display-name>
 	<services-tenant-singular>Location</services-tenant-singular>
 	<services-tenant-doctype>Locationitem</services-tenant-doctype>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-location.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-location.xml
@@ -4,6 +4,7 @@
 
 	<services-tenant-auth-singular>Locationauthority</services-tenant-auth-singular>
 	<services-tenant-auth-plural>Locationauthorities</services-tenant-auth-plural>
+  <services-tenant-auth-display-name>Storage Location</services-tenant-auth-display-name>
 	<services-tenant-singular>Location</services-tenant-singular>
 	<services-tenant-doctype>Locationitem</services-tenant-doctype>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-location.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-location.xml
@@ -31,12 +31,12 @@
 		<instance id="location-location">
 			<web-url>location</web-url>
 			<title-ref>location</title-ref>
-			<title>Local Storage Locations</title>
+			<title>Local</title>
 		</instance>
 		<instance id="location-offsite_sla">
 			<web-url>offsite_sla</web-url>
 			<title-ref>offsite_sla</title-ref>
-			<title>Offsite Storage Locations</title>
+			<title>Offsite</title>
 		</instance>
 	</instances>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-material.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-material.xml
@@ -4,6 +4,7 @@
 
 	<services-tenant-auth-singular>Materialauthority</services-tenant-auth-singular>
 	<services-tenant-auth-plural>Materialauthorities</services-tenant-auth-plural>
+	<services-tenant-auth-display-name>Material</services-tenant-auth-display-name>
 	<services-tenant-singular>Material</services-tenant-singular>
 	<services-tenant-doctype>Materialitem</services-tenant-doctype>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-organization.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-organization.xml
@@ -4,6 +4,7 @@
 
 	<services-tenant-auth-plural>Orgauthorities</services-tenant-auth-plural>
 	<services-tenant-auth-singular>Orgauthority</services-tenant-auth-singular>
+	<services-tenant-auth-display-name>Organization</services-tenant-auth-display-name>
 	<services-tenant-singular>Organization</services-tenant-singular>
 
 	<services-instances-path>orgauthorities_common:http://collectionspace.org/services/organization,abstract-common-list/list-item</services-instances-path>

--- a/tomcat-main/src/main/resources/defaults/base-authority-organization.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-organization.xml
@@ -31,12 +31,12 @@
 		<instance id="organization-organization">
 			<web-url>organization</web-url>
 			<title-ref>organization</title-ref>
-			<title>Local Organizations</title>
+			<title>Local</title>
 		</instance>
 		<instance id="organization-ulan_oa">
 			<web-url>ulan_oa</web-url>
 			<title-ref>ulan_oa</title-ref>
-			<title>ULAN Organizations</title>
+			<title>ULAN</title>
 		</instance>
 	</instances>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-person.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-person.xml
@@ -32,12 +32,12 @@
 		<instance id="person-person">
 			<web-url>person</web-url>
 			<title-ref>person</title-ref>
-			<title>Local Persons</title>
+			<title>Local</title>
 		</instance>
 		<instance id="person-ulan_pa">
 			<web-url>ulan_pa</web-url>
 			<title-ref>ulan_pa</title-ref>
-			<title>ULAN Persons</title>
+			<title>ULAN</title>
 		</instance>
 	</instances>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-person.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-person.xml
@@ -4,6 +4,7 @@
 
 	<services-tenant-auth-singular>Personauthority</services-tenant-auth-singular>
 	<services-tenant-auth-plural>Personauthorities</services-tenant-auth-plural>
+	<services-tenant-auth-display-name>Person</services-tenant-auth-display-name>
 	<services-tenant-singular>Person</services-tenant-singular>
 
 	<services-instances-path>personauthorities_common:http://collectionspace.org/services/person,abstract-common-list/list-item</services-instances-path>

--- a/tomcat-main/src/main/resources/defaults/base-authority-place.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-place.xml
@@ -15,6 +15,7 @@
 	<services-record-path id="collectionspace_core">collectionspace_core:http://collectionspace.org/collectionspace_core/,collectionspace_core</services-record-path>
 	<services-url>placeauthorities</services-url>
 	<authority-vocab-type>PlaceAuthority</authority-vocab-type>
+	<authority-label>Place</authority-label>
 
 	<supportsReplicating>true</supportsReplicating>
 	<remoteClientConfigName>default</remoteClientConfigName>
@@ -33,17 +34,17 @@
 		<instance id="place-place">
 			<web-url>place</web-url>
 			<title-ref>place</title-ref>
-			<title>Local Places</title>
+			<title>Local</title>
 		</instance>
 		<instance id="place-tgn_place">
 			<web-url>tgn_place</web-url>
 			<title-ref>tgn_place</title-ref>
-			<title>Thesaurus of Geographic Names</title>
+			<title>TGN</title>
 		</instance>
 		<instance id="place-archaeological">
 			<web-url>archaeological</web-url>
 			<title-ref>archaeological</title-ref>
-			<title>Archaeological Site</title>
+			<title>Archaeological</title>
 		</instance>
 	</instances>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-place.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-place.xml
@@ -4,6 +4,7 @@
 
 	<services-tenant-auth-singular>Placeauthority</services-tenant-auth-singular>
 	<services-tenant-auth-plural>Placeauthorities</services-tenant-auth-plural>
+	<services-tenant-auth-display-name>Place</services-tenant-auth-display-name>
 	<services-tenant-singular>Place</services-tenant-singular>
 	<services-tenant-doctype>Placeitem</services-tenant-doctype>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-place.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-place.xml
@@ -15,7 +15,6 @@
 	<services-record-path id="collectionspace_core">collectionspace_core:http://collectionspace.org/collectionspace_core/,collectionspace_core</services-record-path>
 	<services-url>placeauthorities</services-url>
 	<authority-vocab-type>PlaceAuthority</authority-vocab-type>
-	<authority-label>Place</authority-label>
 
 	<supportsReplicating>true</supportsReplicating>
 	<remoteClientConfigName>default</remoteClientConfigName>

--- a/tomcat-main/src/main/resources/defaults/base-authority-taxon.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-taxon.xml
@@ -4,6 +4,7 @@
 
 	<services-tenant-auth-singular>Taxonomyauthority</services-tenant-auth-singular>
 	<services-tenant-auth-plural>Taxonomyauthority</services-tenant-auth-plural>
+	<services-tenant-auth-display-name>Taxon</services-tenant-auth-display-name>
 	<services-tenant-singular>Taxon</services-tenant-singular>
 	<services-tenant-plural>Taxon</services-tenant-plural>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-taxon.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-taxon.xml
@@ -31,12 +31,12 @@
 		<instance id="taxon-taxon">
 			<web-url>taxon</web-url>
 			<title-ref>taxon</title-ref>
-			<title>Local Taxa</title>
+			<title>Local</title>
 		</instance>
 		<instance id="taxon-common_ta">
 			<web-url>common_ta</web-url>
 			<title-ref>common_ta</title-ref>
-			<title>Common Taxa</title>
+			<title>Common</title>
 		</instance>
 	</instances>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-work.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-work.xml
@@ -7,6 +7,7 @@
 
 	<services-tenant-auth-singular>Workauthority</services-tenant-auth-singular>
 	<services-tenant-auth-plural>Workauthorities</services-tenant-auth-plural>
+	<services-tenant-auth-display-name>Work</services-tenant-auth-display-name>
 	<services-tenant-singular>Work</services-tenant-singular>
 	<services-tenant-doctype>Workitem</services-tenant-doctype>
 

--- a/tomcat-main/src/main/resources/defaults/base-authority-work.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-work.xml
@@ -33,12 +33,12 @@
 		<instance id="work-work" create-unreferenced="true">
 			<web-url>work</web-url>
 			<title-ref>work</title-ref>
-			<title>Local Works</title>
+			<title>Local</title>
 		</instance>
 		<instance id="work-cona_work" create-unreferenced="true">
 			<web-url>cona_work</web-url>
 			<title-ref>cona_work</title-ref>
-			<title>CONA Works</title>
+			<title>CONA</title>
 		</instance>
 	</instances>
 

--- a/tomcat-main/src/main/resources/defaults/extensions/fineart-authority-concept.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fineart-authority-concept.xml
@@ -7,17 +7,17 @@
 		<instance id="concept-concept">
 			<web-url>concept</web-url>
 			<title-ref>concept</title-ref>
-			<title>Associated Concepts</title>
+			<title>Associated</title>
 		</instance>
 		<instance id="concept-material_ca">
 			<web-url>material_ca</web-url>
 			<title-ref>material_ca</title-ref>
-			<title>Material Concepts</title>
+			<title>Material</title>
 		</instance>
 		<instance id="concept-activity">
 			<web-url>activity</web-url>
 			<title-ref>activity</title-ref>
-			<title>Activity Concepts</title>
+			<title>Activity</title>
 		</instance>
 		<!-- Add ethculture -->
 		<instance id="concept-ethculture">
@@ -34,7 +34,7 @@
 		<instance id="concept-occasion">
 			<web-url>occasion</web-url>
 			<title-ref>occasion</title-ref>
-			<title>Occasion Concepts</title>
+			<title>Occasion</title>
 		</instance>
 	</instances>
 

--- a/tomcat-main/src/main/resources/tenants/anthro/anthro-authority-chronology.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/anthro-authority-chronology.xml
@@ -3,17 +3,17 @@
     <instance id="chronology-era">
       <web-url>era</web-url>
       <title-ref>era</title-ref>
-      <title>Era Chronologies</title>
+      <title>Era</title>
     </instance>
     <instance id="chronology-event">
       <web-url>event</web-url>
       <title-ref>event</title-ref>
-      <title>Event Chronologies</title>
+      <title>Event</title>
     </instance>
     <instance id="chronology-field_collection">
       <web-url>field_collection</web-url>
       <title-ref>field_collection</title-ref>
-      <title>Field Collection Chronologies</title>
+      <title>Field Collection</title>
     </instance>
   </instances>
 </record>

--- a/tomcat-main/src/main/resources/tenants/anthro/anthro-authority-concept.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/anthro-authority-concept.xml
@@ -3,17 +3,17 @@
 		<instance id="concept-concept">
 			<web-url>concept</web-url>
 			<title-ref>concept</title-ref>
-			<title>Associated Concepts</title>
+			<title>Associated</title>
 		</instance>
 		<instance id="concept-material_ca">
 			<web-url>material_ca</web-url>
 			<title-ref>material_ca</title-ref>
-			<title>Material Concepts</title>
+			<title>Material</title>
 		</instance>
 		<instance id="concept-activity">
 			<web-url>activity</web-url>
 			<title-ref>activity</title-ref>
-			<title>Activity Concepts</title>
+			<title>Activity</title>
 		</instance>
 		<instance id="concept-nomenclature">
 			<web-url>nomenclature</web-url>
@@ -23,23 +23,23 @@
 		<instance id="concept-archculture">
 			<web-url>archculture</web-url>
 			<title-ref>archculture</title-ref>
-			<title>Archaeological Cultures</title>
+			<title>Archaeological Culture</title>
 		</instance>
 		<instance id="concept-ethculture">
 			<web-url>ethculture</web-url>
 			<title-ref>ethculture</title-ref>
-			<title>Ethnographic Cultures</title>
+			<title>Cultural Group</title>
 		</instance>
 		<instance id="concept-ethfilecode">
 			<web-url>ethfilecode</web-url>
 			<title-ref>ethfilecode</title-ref>
-			<title>Ethnographic File Codes</title>
+			<title>Function</title>
 		</instance>
 		<!-- For the UOC Occasion field -->
 		<instance id="concept-occasion">
 			<web-url>occasion</web-url>
 			<title-ref>occasion</title-ref>
-			<title>Occasion Concepts</title>
+			<title>Occasion</title>
 		</instance>
 	</instances>
 </record>

--- a/tomcat-main/src/main/resources/tenants/herbarium/herbarium-authority-concept.xml
+++ b/tomcat-main/src/main/resources/tenants/herbarium/herbarium-authority-concept.xml
@@ -24,7 +24,7 @@
 		<instance id="concept-materialclassification">
 			<web-url>materialclassification</web-url>
 			<title-ref>materialclassification</title-ref>
-			<title>Material</title>
+			<title>Material Classification</title>
 		</instance>
 		<instance id="concept-materialformtype">
 			<web-url>materialformtype</web-url>

--- a/tomcat-main/src/main/resources/tenants/herbarium/herbarium-authority-concept.xml
+++ b/tomcat-main/src/main/resources/tenants/herbarium/herbarium-authority-concept.xml
@@ -1,20 +1,19 @@
 <record id="concept">
-	<!-- Add label text vocabulary-->
 	<instances id="concept">
 		<instance id="concept-concept">
 			<web-url>concept</web-url>
 			<title-ref>concept</title-ref>
-			<title>Associated Concepts</title>
+			<title>Associated</title>
 		</instance>
 		<instance id="concept-material_ca">
 			<web-url>material_ca</web-url>
 			<title-ref>material_ca</title-ref>
-			<title>Material Concepts</title>
+			<title>Material</title>
 		</instance>
 		<instance id="concept-activity">
 			<web-url>activity</web-url>
 			<title-ref>activity</title-ref>
-			<title>Activity Concepts</title>
+			<title>Activity</title>
 		</instance>
 		<instance id="concept-nomenclature">
 			<web-url>nomenclature</web-url>
@@ -25,7 +24,7 @@
 		<instance id="concept-materialclassification">
 			<web-url>materialclassification</web-url>
 			<title-ref>materialclassification</title-ref>
-			<title>Material Classifications</title>
+			<title>Material</title>
 		</instance>
 		<instance id="concept-materialformtype">
 			<web-url>materialformtype</web-url>
@@ -36,13 +35,13 @@
 		<instance id="concept-occasion">
 			<web-url>occasion</web-url>
 			<title-ref>occasion</title-ref>
-			<title>Occasion Concepts</title>
+			<title>Occasion</title>
 		</instance>
-		<!-- For herbarium profile -->
+    <!-- Add label text vocabulary for herbarium profile -->
 		<instance id="concept-labeltext">
 			<web-url>labeltext</web-url>
 			<title-ref>labeltext</title-ref>
-			<title>Label Text</title>
+			<title>Label</title>
 		</instance>
 	</instances>
 </record>

--- a/tomcat-main/src/main/resources/tenants/materials/materials-authority-citation.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/materials-authority-citation.xml
@@ -3,13 +3,13 @@
 		<instance id="citation-citation">
 			<web-url>citation</web-url>
 			<title-ref>citation</title-ref>
-			<title>Local Citations</title>
+			<title>Local</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 		<instance id="citation-citation_shared">
 			<web-url>citation_shared</web-url>
 			<title-ref>citation_shared</title-ref>
-			<title>Shared Citations</title>
+			<title>Shared</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 	</instances>

--- a/tomcat-main/src/main/resources/tenants/materials/materials-authority-concept.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/materials-authority-concept.xml
@@ -3,20 +3,20 @@
 		<instance id="concept-materialclassification">
 			<web-url>materialclassification</web-url>
 			<title-ref>materialclassification</title-ref>
-			<title>Material Classifications</title>
+			<title>Material Classification</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 		<instance id="concept-materialclassification_shared">
 			<web-url>materialclassification_shared</web-url>
 			<title-ref>materialclassification_shared</title-ref>
-			<title>Shared Material Classifications</title>
+			<title>Shared Material Classification</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 		<!-- For the UOC Occasion field -->
 		<instance id="concept-occasion">
 			<web-url>occasion</web-url>
 			<title-ref>occasion</title-ref>
-			<title>Occasion Concepts</title>
+			<title>Occasion</title>
 		</instance>
 	</instances>
 </record>

--- a/tomcat-main/src/main/resources/tenants/materials/materials-authority-location.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/materials-authority-location.xml
@@ -3,13 +3,13 @@
 		<instance id="location-location">
 			<web-url>location</web-url>
 			<title-ref>location</title-ref>
-			<title>Local Storage Locations</title>
+			<title>Local</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 		<instance id="location-offsite_sla">
 			<web-url>offsite_sla</web-url>
 			<title-ref>offsite_sla</title-ref>
-			<title>Offsite Storage Locations</title>
+			<title>Offsite</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 	</instances>

--- a/tomcat-main/src/main/resources/tenants/materials/materials-authority-material.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/materials-authority-material.xml
@@ -5,13 +5,13 @@
 		<instance id="material-material">
 			<web-url>material</web-url>
 			<title-ref>material</title-ref>
-			<title>Local Materials</title>
+			<title>Local</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 		<instance id="material-material_shared">
 			<web-url>material_shared</web-url>
 			<title-ref>material_shared</title-ref>
-			<title>Shared Materials</title>
+			<title>Shared</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 	</instances>

--- a/tomcat-main/src/main/resources/tenants/materials/materials-authority-organization.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/materials-authority-organization.xml
@@ -3,13 +3,13 @@
 		<instance id="organization-organization">
 			<web-url>organization</web-url>
 			<title-ref>organization</title-ref>
-			<title>Local Organizations</title>
+			<title>Local</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 		<instance id="organization-organization_shared">
 			<web-url>organization_shared</web-url>
 			<title-ref>organization_shared</title-ref>
-			<title>Shared Organizations</title>
+			<title>Shared</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 	</instances>

--- a/tomcat-main/src/main/resources/tenants/materials/materials-authority-person.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/materials-authority-person.xml
@@ -3,13 +3,13 @@
 		<instance id="person-person">
 			<web-url>person</web-url>
 			<title-ref>person</title-ref>
-			<title>Local Persons</title>
+			<title>Local</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 		<instance id="person-person_shared">
 			<web-url>person_shared</web-url>
 			<title-ref>person_shared</title-ref>
-			<title>Shared Persons</title>
+			<title>Shared</title>
 		</instance>
 	</instances>
 </record>

--- a/tomcat-main/src/main/resources/tenants/materials/materials-authority-place.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/materials-authority-place.xml
@@ -3,13 +3,13 @@
 		<instance id="place-place">
 			<web-url>place</web-url>
 			<title-ref>place</title-ref>
-			<title>Local Places</title>
+			<title>Local</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 		<instance id="place-place_shared">
 			<web-url>place_shared</web-url>
 			<title-ref>place_shared</title-ref>
-			<title>Shared Places</title>
+			<title>Shared</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 	</instances>

--- a/tomcat-main/src/main/resources/tenants/materials/materials-authority-work.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/materials-authority-work.xml
@@ -3,13 +3,13 @@
 		<instance id="work-work">
 			<web-url>work</web-url>
 			<title-ref>work</title-ref>
-			<title>Local Works</title>
+			<title>Local</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 		<instance id="work-work_shared">
 			<web-url>work_shared</web-url>
 			<title-ref>work_shared</title-ref>
-			<title>Shared Works</title>
+			<title>Shared</title>
 			<nptAllowed>false</nptAllowed>
 		</instance>
 	</instances>

--- a/tomcat-main/src/main/resources/tenants/publicart/publicart-authority-citation.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/publicart-authority-citation.xml
@@ -3,7 +3,7 @@
 		<instance id="citation-citation">
 			<web-url>citation</web-url>
 			<title-ref>citation</title-ref>
-			<title>Local Citations</title>
+			<title>Local</title>
 			<options>
 				<option id="getty_att">Getty AAT</option>
 			</options>
@@ -11,7 +11,7 @@
 		<instance id="citation-worldcat">
 			<web-url>worldcat</web-url>
 			<title-ref>worldcat</title-ref>
-			<title>WorldCat Citations</title>
+			<title>WorldCat</title>
 		</instance>
 	</instances>
 </record>

--- a/tomcat-main/src/main/resources/tenants/publicart/publicart-authority-concept.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/publicart-authority-concept.xml
@@ -7,12 +7,12 @@
 		<instance id="concept-concept">
 			<web-url>concept</web-url>
 			<title-ref>concept</title-ref>
-			<title>Associated Concepts</title>
+			<title>Associated</title>
 		</instance>
 		<instance id="concept-material_ca">
 			<web-url>material_ca</web-url>
 			<title-ref>material_ca</title-ref>
-			<title>Material Concepts</title>
+			<title>Material</title>
 			<options>
 				<option id="abrasive">abrasive</option>
 				<option id="acetate_film">acetate film</option>
@@ -232,7 +232,7 @@
 		<instance id="concept-worktype">
 			<web-url>worktype</web-url>
 			<title-ref>worktype</title-ref>
-			<title>Work Types</title>
+			<title>Work Type</title>
 			<options>
 				<option id="acrylicpaintings">acrylic paintings</option>
 				<option id="architecturaldrawings_visualworks">architectural drawings (visual works)</option>

--- a/tomcat-main/src/main/resources/tenants/publicart/publicart-authority-location.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/publicart-authority-location.xml
@@ -5,12 +5,12 @@
 		<instance id="location-location">
 			<web-url>location</web-url>
 			<title-ref>location</title-ref>
-			<title>Local Storage Locations</title>
+			<title>Local</title>
 		</instance>
 		<instance id="location-offsite_sla">
 			<web-url>offsite_sla</web-url>
 			<title-ref>offsite_sla</title-ref>
-			<title>Offsite Storage Locations</title>
+			<title>Offsite</title>
 		</instance>
 	</instances>
 

--- a/tomcat-main/src/main/resources/tenants/publicart/publicart-authority-organization.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/publicart-authority-organization.xml
@@ -5,17 +5,17 @@
 		<instance id="organization-organization">
 			<web-url>organization</web-url>
 			<title-ref>organization</title-ref>
-			<title>Local Organizations</title>
+			<title>Local</title>
 		</instance>
 		<instance id="organization-organization_shared">
 			<web-url>organization_shared</web-url>
 			<title-ref>organization_shared</title-ref>
-			<title>Shared Organizations</title>
+			<title>Shared</title>
 		</instance>
 		<instance id="organization-ulan_oa">
 			<web-url>ulan_oa</web-url>
 			<title-ref>ulan_oa</title-ref>
-			<title>ULAN Organizations</title>
+			<title>ULAN</title>
 		</instance>
 	</instances>
 

--- a/tomcat-main/src/main/resources/tenants/publicart/publicart-authority-person.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/publicart-authority-person.xml
@@ -5,17 +5,17 @@
 		<instance id="person-person">
 			<web-url>person</web-url>
 			<title-ref>person</title-ref>
-			<title>Local Persons</title>
+			<title>Local</title>
 		</instance>
 		<instance id="person-ulan_pa">
 			<web-url>ulan_pa</web-url>
 			<title-ref>ulan_pa</title-ref>
-			<title>ULAN Persons</title>
+			<title>ULAN</title>
 		</instance>
 		<instance id="person-person_shared">
 			<web-url>person_shared</web-url>
 			<title-ref>person_shared</title-ref>
-			<title>Shared Persons</title>
+			<title>Shared</title>
 		</instance>
 	</instances>
 

--- a/tomcat-main/src/main/resources/tenants/publicart/publicart-authority-place.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/publicart-authority-place.xml
@@ -6,17 +6,17 @@
 		<instance id="place-place">
 			<web-url>place</web-url>
 			<title-ref>place</title-ref>
-			<title>Local Places</title>
+			<title>Local</title>
 		</instance>
 		<instance id="place-tgn_place">
 			<web-url>tgn_place</web-url>
 			<title-ref>tgn_place</title-ref>
-			<title>Thesaurus of Geographic Names</title>
+			<title>TGN</title>
 		</instance>
 		<instance id="place-place_shared">
 			<web-url>place_shared</web-url>
 			<title-ref>place_shared</title-ref>
-			<title>Shared Places</title>
+			<title>Shared</title>
 		</instance>
 	</instances>
 


### PR DESCRIPTION
**What does this do?**
Adds display name support for Authorities in order to provide a standard name to the services layer
Update authorities to include a display name
Update authority vocab titles to match cspace-ui.js or the respective profile plugin

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1837

This is a requirement for the above ticket in order to better align the backend and frontend display names for authorities and their instances (vocabularies). Currently I only have the location authority updated to show how the display name for the authority can be updated as well as the authority instances.

**How should this be tested? Do these changes have associated tests?**
Testing this is kind of awkward because the display names are still defined in multiple places, but we should be able to check the tenant bindings compared to the ui or dev sites to verify consistency. I used `xq` in order to get information out of the bindings.

For the authority display names
* For each tenant binding, get the display names, e.g.
```
cd ${tomcat}/cspace/config/services/tenants
xq '."tenant:TenantBindingConfig"."tenant:tenantBinding"."tenant:serviceBindings" | map(select(."@id" | contains("authorit"))) | map([."@id", ."@name", ."@displayName"]) ' anthro/tenant-bindings.merged.xml
# or if csv output is easier
xq '."tenant:TenantBindingConfig"."tenant:tenantBinding"."tenant:serviceBindings" | map(select(."@displayName")) | map([."@id", ."@name", ."@displayName"]) | .[] | @csv' anthro/tenant-bindings.merged.xml
```
  * Verify each output is found in the ui
  * Also a small note - I noticed some tenants have authorities enabled in their bindings but not in the ui. We should follow up on this. 

For the authority vocabs
* Similar to the above, but get the authority with a list of authority vocabs
```
cd ${tomcat}/cspace/config/services/tenants
xq '."tenant:TenantBindingConfig"."tenant:tenantBinding"."tenant:serviceBindings" | map(select(."@displayName")) | map({authority: ."@displayName", vocabs: [."service:AuthorityInstanceList"."service:AuthorityInstance"[]."service:title"]}) ' anthro/tenant-bindings.merged.xml
```

- [x] anthro - authority display name
- [x] anthro - authority vocabs
- [x] bonsai - authority display name
- [x] bonsai - authority vocabs
- [x] core - authority display name
- [x] core - authority vocabs
- [x] fcart - authority display name
- [x] fcart - authority vocabs
- [x] herbarium - authority display name
- [x] herbarium - authority vocabs
- [x] lhmc - authority display name
- [x] lhmc - authority vocabs
- [x] materials - authority display name
- [x] materials - authority vocabs
- [x] publicart - authority display name
- [x] publicart - authority vocabs

**Dependencies for merging? Releasing to production?**
It would be good to double check that the `title` field for authorities isn't being used. I know it gets stored in the database, but I don't believe anything is ever actually done for it.

**Has the application documentation been updated for these changes?**
Documentation on the csmake tool needs to be updated or started if it does not exist.

**Did someone actually run this code to verify it works?**
@mikejritter tested locally