### PR TITLE
DRYD-1904: Object Record > Anthro > Add Material/technique description

### DIFF
--- a/tomcat-main/src/main/resources/tenants/anthro/anthro-collectionobject.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/anthro-collectionobject.xml
@@ -37,6 +37,7 @@
 
 			<field id="commingledRemainsNote" section="anthro" />
 		</repeat>
+		<field id="materialTechniqueDescription" section="anthro" />
 	</section>
 
 	<section id="objectProductionInformation">


### PR DESCRIPTION
**What does this do?**
It adds the `materialTechniqueDescription` field in the anthro tenant.

**Why are we doing this? (with JIRA link)**
https://collectionspace.atlassian.net/browse/DRYD-1904

**How should this be tested? Do these changes have associated tests?**
Please check the https://github.com/collectionspace/cspace-ui-plugin-profile-anthro.js/pull/38

**Dependencies for merging? Releasing to production?**
No dependencies. It is a dependency of https://github.com/collectionspace/cspace-ui-plugin-profile-anthro.js/pull/38

**Has the application documentation been updated for these changes?**
no need for update

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally
