### PR TITLE
DRYD-1982: Add alt text to list response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CollectionSpace Application Changelog
 
+## 8.3.0
+
+## Procedures
+
+### Media
+
+* Add `mini="list"` to alt text
+
 ## 8.2.0
 
 ## Procedures

--- a/tomcat-main/src/main/resources/defaults/base-procedure-media.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-media.xml
@@ -55,7 +55,7 @@
 		</repeat>
 		<field id="rightsHolder" autocomplete="true" />
 		<field id="description" />
-		<field id="altText" />
+		<field id="altText" mini="list" />
 
 		<repeat id="checksumGroupList/checksumGroup">
 			<field id="checksumValue" />


### PR DESCRIPTION
**What does this do?**
Add `mini="list"` to alt text in order to add it to the list response

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1982

This was missing in the response when querying the media resource `getList` from the advanced search. I figured the quickest way to get it would be to update the xml here to include the field in the response.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Create a media record with some alt text
* Query the media api in order to see the alt text, e.g.
```
[cspace] $ curl -u admin@core.collectionspace.org:Administrator 'http://localhost:8180/cspace-services/media' -H 'Accept: application/json' | jq .         
{
  "ns2:abstract-common-list": {
    "@xmlns:ns2": "http://collectionspace.org/services/jaxb",
    "pageNum": "0",
    "pageSize": "40",
    "itemsInPage": "1",
    "totalItems": "1",
    "fieldsReturned": "csid|uri|refName|updatedAt|workflowState|altText|identificationNumber|blobCsid|title",
    "list-item": {
      "csid": "4495286b-9d26-45ec-8101",
      "uri": "/media/4495286b-9d26-45ec-8101",
      "refName": "urn:cspace:core.collectionspace.org:media:id(4495286b-9d26-45ec-8101)",
      "updatedAt": "2025-12-09T19:25:38.300Z",
      "workflowState": "project",
      "altText": "alt text",
      "identificationNumber": "MR2025.1.1",
      "blobCsid": "f47f39ae-7a7b-4d84-b412"
    }
  }
}
```

**Dependencies for merging? Releasing to production?**
None. 

**Has the application documentation been updated for these changes?**
The changelog is updated with this PR

**Did someone actually run this code to verify it works?**
@mikejritter tested locally
