### PR TITLE
DRYD-1907: Remove incorrect attribute from identifierCitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 8.3.0
 
+### Authorities
+
+#### Chronology
+
+* Remove `ui-type="enum"` from identifierCitation
+
 ### Procedures
 
 #### Media

--- a/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
+++ b/tomcat-main/src/main/resources/defaults/base-authority-chronology.xml
@@ -58,7 +58,7 @@
 
     <repeat id="identifierGroupList/identifierGroup">
       <field id="identifierValue" />
-      <field id="identifierCitation" autocomplete="true" ui-type="enum" />
+      <field id="identifierCitation" autocomplete="true" />
       <field id="identifierDate" />
     </repeat>
 


### PR DESCRIPTION
**What does this do?**
* Remove ui-type="enum" from identifierCitation

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1907

The errant attribute is causing the `identifierCitation` field to be configured as a term ref instead of an auth ref, which is causing the values in this field to not be returned when querying for terms used. 

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Create a Chronology with a citation
* See the citation shows up in the 'Terms Used' panel

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
I've started on some documentation around the XML tags and attributes, though it's still pretty rough. I need to double check to make sure at least the `autocomplete` and `ui-type="enum"` meanings are defined.

**Did someone actually run this code to verify it works?**
@mikejritter tested locally. The change was verified in the ticket as well.