### PR TITLE
Terms/org types and annotation types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,25 @@
 
 ## 8.3.0
 
-## Procedures
+### Procedures
 
-### Media
+#### Media
 
 * Add `mini="list"` to alt text
+
+### Term Lists
+
+#### Annotation Type
+
+**All Profiles**
+
+* Update default terms to catalog note, legacy data note, and staff note
+
+#### Organization Types
+
+**Core, Bonsai, BotGarden, FCART, Herbarium, LHMC, Materials**
+
+* Add federally-recognized tribe and non-federally-recognized tribe to default terms
 
 ## 8.2.0
 

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -508,6 +508,8 @@
 			<option id="repository">repository</option>
 			<option id="studio">studio</option>
 			<option id="workshop">workshop</option>
+			<option id="federallyrecognizedtribe">federally-recognized tribe</option>
+			<option id="nonfederallyrecognizedtribe">non-federally-recognized tribe</option>
 		</options>
 	</instance>
 	<instance id="vocab-taxontype">

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -1328,15 +1328,9 @@
 		<title-ref>annotationtype</title-ref>
 		<title>Annotation Type</title>
 		<options>
-			<option id="additional_taxa">additional taxa</option>
-			<option id="deaccession">deaccession</option>
-			<option id="holotype_location">holotype location</option>
-			<option id="image_made">image made</option>
-			<option id="nomenclature">nomenclature</option>
-			<option id="number_collision">number collision</option>
-			<option id="population_biology">population biology</option>
-			<option id="type">type</option>
-			<option id="vegetation_type_map_project">Vegetation Type Map Project</option>
+			<option id="catalognote">catalog note</option>
+			<option id="legacydatanote">legacy data note</option>
+			<option id="staffnote">staff note</option>
 		</options>
 	</instance>
 	<instance id="vocab-insurancetype">

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -518,6 +518,8 @@
 			<option id="repository">repository</option>
 			<option id="studio">studio</option>
 			<option id="workshop">workshop</option>
+			<option id="federallyrecognizedtribe">federally-recognized tribe</option>
+			<option id="nonfederallyrecognizedtribe">non-federally-recognized tribe</option>
 		</options>
 	</instance>
 	<instance id="vocab-taxontype">

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -784,15 +784,9 @@
 		<title-ref>annotationtype</title-ref>
 		<title>Annotation Type</title>
 		<options>
-			<option id="additional_taxa">additional taxa</option>
-			<option id="deaccession">deaccession</option>
-			<option id="holotype_location">holotype location</option>
-			<option id="image_made">image made</option>
-			<option id="nomenclature">nomenclature</option>
-			<option id="number_collision">number collision</option>
-			<option id="population_biology">population biology</option>
-			<option id="type">type</option>
-			<option id="vegetation_type_map_project">Vegetation Type Map Project</option>
+			<option id="catalognote">catalog note</option>
+			<option id="legacydatanote">legacy data note</option>
+			<option id="staffnote">staff note</option>
 		</options>
 	</instance>
 	<instance id="vocab-insurancetype">

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
@@ -509,6 +509,8 @@
 			<option id="repository">repository</option>
 			<option id="studio">studio</option>
 			<option id="workshop">workshop</option>
+			<option id="federallyrecognizedtribe">federally-recognized tribe</option>
+			<option id="nonfederallyrecognizedtribe">non-federally-recognized tribe</option>
 		</options>
 	</instance>
 	<!-- <instance id="vocab-taxontype">

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
@@ -1329,15 +1329,9 @@
 		<title-ref>annotationtype</title-ref>
 		<title>Annotation Type</title>
 		<options>
-			<option id="additional_taxa">additional taxa</option>
-			<option id="deaccession">deaccession</option>
-			<option id="holotype_location">holotype location</option>
-			<option id="image_made">image made</option>
-			<option id="nomenclature">nomenclature</option>
-			<option id="number_collision">number collision</option>
-			<option id="population_biology">population biology</option>
-			<option id="type">type</option>
-			<option id="vegetation_type_map_project">Vegetation Type Map Project</option>
+			<option id="catalognote">catalog note</option>
+			<option id="legacydatanote">legacy data note</option>
+			<option id="staffnote">staff note</option>
 		</options>
 	</instance>
 	<instance id="vocab-insurancetype">

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -526,6 +526,8 @@
 			<option id="repository">repository</option>
 			<option id="studio">studio</option>
 			<option id="workshop">workshop</option>
+			<option id="federallyrecognizedtribe">federally-recognized tribe</option>
+			<option id="nonfederallyrecognizedtribe">non-federally-recognized tribe</option>
 		</options>
 	</instance>
 	<instance id="vocab-taxontype">

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -1312,15 +1312,9 @@
 		<title-ref>annotationtype</title-ref>
 		<title>Annotation Type</title>
 		<options>
-			<option id="additional_taxa">additional taxa</option>
-			<option id="deaccession">deaccession</option>
-			<option id="holotype_location">holotype location</option>
-			<option id="image_made">image made</option>
-			<option id="nomenclature">nomenclature</option>
-			<option id="number_collision">number collision</option>
-			<option id="population_biology">population biology</option>
-			<option id="type">type</option>
-			<option id="vegetation_type_map_project">Vegetation Type Map Project</option>
+			<option id="catalognote">catalog note</option>
+			<option id="legacydatanote">legacy data note</option>
+			<option id="staffnote">staff note</option>
 		</options>
 	</instance>
 	<instance id="vocab-insurancetype">

--- a/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
@@ -1327,15 +1327,9 @@
 		<title-ref>annotationtype</title-ref>
 		<title>Annotation Type</title>
 		<options>
-			<option id="additional_taxa">additional taxa</option>
-			<option id="deaccession">deaccession</option>
-			<option id="holotype_location">holotype location</option>
-			<option id="image_made">image made</option>
-			<option id="nomenclature">nomenclature</option>
-			<option id="number_collision">number collision</option>
-			<option id="population_biology">population biology</option>
-			<option id="type">type</option>
-			<option id="vegetation_type_map_project">Vegetation Type Map Project</option>
+			<option id="catalognote">catalog note</option>
+			<option id="legacydatanote">legacy data note</option>
+			<option id="staffnote">staff note</option>
 		</options>
 	</instance>
 	<instance id="vocab-insurancetype">


### PR DESCRIPTION
**What does this do?**
* Updates annotationtype default terms
* Updates organizationtypes default terms

**Why are we doing this? (with JIRA link)**
Jira:
* https://collectionspace.atlassian.net/browse/DRYD-1910
* https://collectionspace.atlassian.net/browse/DRYD-1911

There are just updating the default terms for these two term lists. For annotation type, we're updating the default terms to only be `catalog note`, `legacy data note`, and`staff note` for all profiles. For organization types, we're adding `federally-recognized tribe` and `non-federally-recognized tribe` to all profiles except publicart.

**How should this be tested? Do these changes have associated tests?**
* Note: Testing should be done on a clean database as we do not delete old terms.
* Rebuild collectionspace
* Query for annotation type and see that the only the 3 terms are returned, e.g.
```
curl -u admin@core.collectionspace.org:Administrator 'http://localhost:8180/cspace-services/vocabularies/urn:cspace:name(annotationtype)/items' -H 'Accept: application/json' | jq .
```
* Query for organizationtypes and see that the 2 new terms are included, e.g.
```
curl -u admin@core.collectionspace.org:Administrator 'http://localhost:8180/cspace-services/vocabularies/urn:cspace:name(organizationtype)/items' -H 'Accept: application/json' | jq .
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
I don't believe there is any documentation to update. The CHANGELOG has been updated.

**Did someone actually run this code to verify it works?**
@mikejritter tested locally