### PR TITLE
Support SMTP configuration via environment variables

### DIFF
--- a/tomcat-main/src/main/resources/tenants/anthro/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/anthro/settings.xml
@@ -27,13 +27,13 @@
 		<to></to>
 		<!-- if specified then all emails will send to this address - used for debugging -->
 		<smtp>
-			<host>localhost</host>
-			<port>25</port>
-			<debug>false</debug>
-			<auth enabled="false">
+			<host>${CSPACE_SMTP_EMAIL_HOST_OPT}</host>
+			<port>${CSPACE_SMTP_EMAIL_PORT_OPT}</port>
+			<debug>${CSPACE_SMTP_EMAIL_AUTH_DEBUG_OPT}</debug>
+			<auth enabled="${CSPACE_SMTP_EMAIL_AUTH_OPT}">
 				<!-- set to true if wish to use auth -->
-				<username></username>
-				<password></password>
+				<username>${CSPACE_SMTP_EMAIL_AUTH_USERNAME_OPT}</username>
+				<password>${CSPACE_SMTP_EMAIL_AUTH_PASSWORD_OPT}</password>
 			</auth>
 		</smtp>
 		<passwordreset>

--- a/tomcat-main/src/main/resources/tenants/bonsai/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/bonsai/settings.xml
@@ -36,13 +36,13 @@
         </passwordreset>
         <!-- if specified then all emails will send to this address - used for debugging -->
         <smtp>
-            <host>localhost</host>
-            <port>25</port>
-            <debug>false</debug>
-            <auth enabled="false">
+            <host>${CSPACE_SMTP_EMAIL_HOST_OPT}</host>
+            <port>${CSPACE_SMTP_EMAIL_PORT_OPT}</port>
+            <debug>${CSPACE_SMTP_EMAIL_AUTH_DEBUG_OPT}</debug>
+            <auth enabled="${CSPACE_SMTP_EMAIL_AUTH_OPT}">
                 <!-- set to true if wish to use auth -->
-                <username></username>
-                <password></password>
+                <username>${CSPACE_SMTP_EMAIL_AUTH_USERNAME_OPT}</username>
+                <password>${CSPACE_SMTP_EMAIL_AUTH_PASSWORD_OPT}</password>
             </auth>
         </smtp>
     </email>

--- a/tomcat-main/src/main/resources/tenants/botgarden/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/settings.xml
@@ -36,13 +36,13 @@
         </passwordreset>
         <!-- if specified then all emails will send to this address - used for debugging -->
         <smtp>
-            <host>localhost</host>
-            <port>25</port>
-            <debug>false</debug>
-            <auth enabled="false">
+            <host>${CSPACE_SMTP_EMAIL_HOST_OPT}</host>
+            <port>${CSPACE_SMTP_EMAIL_PORT_OPT}</port>
+            <debug>${CSPACE_SMTP_EMAIL_AUTH_DEBUG_OPT}</debug>
+            <auth enabled="${CSPACE_SMTP_EMAIL_AUTH_OPT}">
                 <!-- set to true if wish to use auth -->
-                <username></username>
-                <password></password>
+                <username>${CSPACE_SMTP_EMAIL_AUTH_USERNAME_OPT}</username>
+                <password>${CSPACE_SMTP_EMAIL_AUTH_PASSWORD_OPT}</password>
             </auth>
         </smtp>
     </email>

--- a/tomcat-main/src/main/resources/tenants/core/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/core/settings.xml
@@ -27,13 +27,13 @@
 		<to></to>
 		<!-- if specified then all emails will send to this address - used for debugging -->
 		<smtp>
-			<host>localhost</host>
-			<port>25</port>
-			<debug>${CSPACE_CORE_EMAIL_AUTH_DEBUG_OPT}</debug>
-			<auth enabled="false">
+			<host>${CSPACE_SMTP_EMAIL_HOST_OPT}</host>
+			<port>${CSPACE_SMTP_EMAIL_PORT_OPT}</port>
+			<debug>${CSPACE_SMTP_EMAIL_AUTH_DEBUG_OPT}</debug>
+			<auth enabled="${CSPACE_SMTP_EMAIL_AUTH_OPT}">
 				<!-- set to true if wish to use auth -->
-				<username>${CSPACE_CORE_EMAIL_AUTH_USERNAME_OPT}</username>
-				<password>${CSPACE_CORE_EMAIL_AUTH_PASSWORD_OPT}</password>
+				<username>${CSPACE_SMTP_EMAIL_AUTH_USERNAME_OPT}</username>
+				<password>${CSPACE_SMTP_EMAIL_AUTH_PASSWORD_OPT}</password>
 			</auth>
 		</smtp>
 		<passwordreset>

--- a/tomcat-main/src/main/resources/tenants/fcart/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/fcart/settings.xml
@@ -27,13 +27,13 @@
         <to></to>
         <!-- if specified then all emails will send to this address - used for debugging -->
         <smtp>
-            <host>localhost</host>
-            <port>25</port>
-            <debug>false</debug>
-            <auth enabled="false">
+            <host>${CSPACE_SMTP_EMAIL_HOST_OPT}</host>
+            <port>${CSPACE_SMTP_EMAIL_PORT_OPT}</port>
+            <debug>${CSPACE_SMTP_EMAIL_AUTH_DEBUG_OPT}</debug>
+            <auth enabled="${CSPACE_SMTP_EMAIL_AUTH_OPT}">
                 <!-- set to true if wish to use auth -->
-                <username></username>
-                <password></password>
+                <username>${CSPACE_SMTP_EMAIL_AUTH_USERNAME_OPT}</username>
+                <password>${CSPACE_SMTP_EMAIL_AUTH_PASSWORD_OPT}</password>
             </auth>
         </smtp>
         <passwordreset>

--- a/tomcat-main/src/main/resources/tenants/herbarium/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/herbarium/settings.xml
@@ -27,13 +27,13 @@
         <to></to>
         <!-- if specified then all emails will send to this address - used for debugging -->
         <smtp>
-            <host>localhost</host>
-            <port>25</port>
-            <debug>false</debug>
-            <auth enabled="false">
+            <host>${CSPACE_SMTP_EMAIL_HOST_OPT}</host>
+            <port>${CSPACE_SMTP_EMAIL_PORT_OPT}</port>
+            <debug>${CSPACE_SMTP_EMAIL_AUTH_DEBUG_OPT}</debug>
+            <auth enabled="${CSPACE_SMTP_EMAIL_AUTH_OPT}">
                 <!-- set to true if wish to use auth -->
-                <username></username>
-                <password></password>
+                <username>${CSPACE_SMTP_EMAIL_AUTH_USERNAME_OPT}</username>
+                <password>${CSPACE_SMTP_EMAIL_AUTH_PASSWORD_OPT}</password>
             </auth>
         </smtp>
         <passwordreset>

--- a/tomcat-main/src/main/resources/tenants/lhmc/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/lhmc/settings.xml
@@ -27,13 +27,13 @@
 		<to></to>
 		<!-- if specified then all emails will send to this address - used for debugging -->
 		<smtp>
-			<host>localhost</host>
-			<port>25</port>
-			<debug>false</debug>
-			<auth enabled="false">
+			<host>${CSPACE_SMTP_EMAIL_HOST_OPT}</host>
+			<port>${CSPACE_SMTP_EMAIL_PORT_OPT}</port>
+			<debug>${CSPACE_SMTP_EMAIL_AUTH_DEBUG_OPT}</debug>
+			<auth enabled="${CSPACE_SMTP_EMAIL_AUTH_OPT}">
 				<!-- set to true if wish to use auth -->
-				<username></username>
-				<password></password>
+				<username>${CSPACE_SMTP_EMAIL_AUTH_USERNAME_OPT}</username>
+				<password>${CSPACE_SMTP_EMAIL_AUTH_PASSWORD_OPT}</password>
 			</auth>
 		</smtp>
 		<passwordreset>

--- a/tomcat-main/src/main/resources/tenants/materials/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/settings.xml
@@ -27,13 +27,13 @@
         <to></to>
         <!-- if specified then all emails will send to this address - used for debugging -->
         <smtp>
-            <host>localhost</host>
-            <port>25</port>
-            <debug>false</debug>
-            <auth enabled="false">
+            <host>${CSPACE_SMTP_EMAIL_HOST_OPT}</host>
+            <port>${CSPACE_SMTP_EMAIL_PORT_OPT}</port>
+            <debug>${CSPACE_SMTP_EMAIL_AUTH_DEBUG_OPT}</debug>
+            <auth enabled="${CSPACE_SMTP_EMAIL_AUTH_OPT}">
                 <!-- set to true if wish to use auth -->
-                <username></username>
-                <password></password>
+                <username>${CSPACE_SMTP_EMAIL_AUTH_USERNAME_OPT}</username>
+                <password>${CSPACE_SMTP_EMAIL_AUTH_PASSWORD_OPT}</password>
             </auth>
         </smtp>
         <passwordreset>

--- a/tomcat-main/src/main/resources/tenants/publicart/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/settings.xml
@@ -27,13 +27,13 @@
         <to></to>
         <!-- if specified then all emails will send to this address - used for debugging -->
         <smtp>
-            <host>localhost</host>
-            <port>25</port>
-            <debug>false</debug>
-            <auth enabled="false">
+            <host>${CSPACE_SMTP_EMAIL_HOST_OPT}</host>
+            <port>${CSPACE_SMTP_EMAIL_PORT_OPT}</port>
+            <debug>${CSPACE_SMTP_EMAIL_AUTH_DEBUG_OPT}</debug>
+            <auth enabled="${CSPACE_SMTP_EMAIL_AUTH_OPT}">
                 <!-- set to true if wish to use auth -->
-                <username></username>
-                <password></password>
+                <username>${CSPACE_SMTP_EMAIL_AUTH_USERNAME_OPT}</username>
+                <password>${CSPACE_SMTP_EMAIL_AUTH_PASSWORD_OPT}</password>
             </auth>
         </smtp>
         <passwordreset>

--- a/tomcat-main/src/main/resources/tenants/testsci/settings.xml
+++ b/tomcat-main/src/main/resources/tenants/testsci/settings.xml
@@ -27,13 +27,13 @@
         <to></to>
         <!-- if specified then all emails will send to this address - used for debugging -->
         <smtp>
-            <host>localhost</host>
-            <port>25</port>
-            <debug>false</debug>
-            <auth enabled="false">
+            <host>${CSPACE_SMTP_EMAIL_HOST_OPT}</host>
+            <port>${CSPACE_SMTP_EMAIL_PORT_OPT}</port>
+            <debug>${CSPACE_SMTP_EMAIL_AUTH_DEBUG_OPT}</debug>
+            <auth enabled="${CSPACE_SMTP_EMAIL_AUTH_OPT}">
                 <!-- set to true if wish to use auth -->
-                <username></username>
-                <password></password>
+                <username>${CSPACE_SMTP_EMAIL_AUTH_USERNAME_OPT}</username>
+                <password>${CSPACE_SMTP_EMAIL_AUTH_PASSWORD_OPT}</password>
             </auth>
         </smtp>
         <passwordreset>


### PR DESCRIPTION
**What does this do?**
Configures SMTP via environment variables.

**Why are we doing this? (with JIRA link)**
There was a request to configure dev environments with valid SMTP credentials. The existing `settings.xml` files had hardcoded local settings.

**How should this be tested? Do these changes have associated tests?**
These variables are already used in deployments, so they're known to work. There are not tests associated with this PR.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
No.

**Did someone actually run this code to verify it works?**
Yes.
