### PR TITLE
DRYD-2019: Add controlled content place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 #### CollectionObject
 
 * **Anthro** Add material/technique description free text field
+* Add repeating autocomplete field `controlledContentPlaces/controlledContentPlace`
 
 #### Media
 

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -254,6 +254,9 @@
 			<repeat id="contentPersons">
 				<field id="contentPerson" autocomplete="true" />
 			</repeat>
+			<repeat id="controlledContentPlaces">
+				<field id="controlledContentPlace" autocomplete="true" />
+			</repeat>
 			<repeat id="contentPlaces">
 				<field id="contentPlace" />
 			</repeat>


### PR DESCRIPTION
**What does this do?**
* Adds a new repeating field, controlled content place

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2019

This is a field which is needed for an upcoming data migration.

**How should this be tested? Do these changes have associated tests?**
It's better to test with the change to [cspace-ui.js](https://github.com/collectionspace/cspace-ui.js/pull/330) as well, but as a sanity check this can be tested by:
* Rebuild and start CollectionSpace with this PR
* Connect to the `nuxeo_default` database
* See that the new table was created for the controlledContentPlace repeating field, e.g.
```
nuxeo_default=# \d collectionobjects_common_controlledcontentplaces
 Table "public.collectionobjects_common_controlledcontentplaces"
 Column |         Type          | Collation | Nullable | Default 
--------+-----------------------+-----------+----------+---------
 id     | character varying(36) |           | not null | 
 pos    | integer               |           |          | 
 item   | character varying     |           |          | 
Indexes:
    "collectionobjects_common_controlledcontentplaces_id_idx" btree (id)
    "collectionobjects_common_controlledcontentplaces_unique_pos" UNIQUE, btree (id, pos)
Foreign-key constraints:
    "coll_ec36c1f7_fk" FOREIGN KEY (id) REFERENCES hierarchy(id) ON DELETE CASCADE
``` 

**Dependencies for merging? Releasing to production?**
This will need the ui changes in order to be usable. Likewise, controlled versions of the contentPlace field already exist for bonsai, lhmc, and fcart, though that shouldn't affect this PR.

**Has the application documentation been updated for these changes?**
The CHANGELOG has been updated

**Did someone actually run this code to verify it works?**
@mikejritter tested locally