### PR TITLE
DRYD-2028: Procedure > Consultation > Add consultation outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 * Add free text field `acquisitionDescription`
 * Add parties involved group `partiesInvovledGroupList/partiesInvolvedGroup`
 
+#### Consultation
+
+* Add repeatable field `consultationOutcomes/consultationOutcome`
+
 #### Deaccession
 
 * Add parties involved group `partiesInvovledGroupList/partiesInvolvedGroup`

--- a/tomcat-main/src/main/resources/defaults/base-procedure-consultation.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-consultation.xml
@@ -35,6 +35,10 @@
       <field id="consultDate" datatype="date" />
       <field id="consultNote" />
     </repeat>
+
+    <repeat id="consultationOutcomes">
+      <field id="consultationOutcome" />
+    </repeat>
   </section>
 
 </record>


### PR DESCRIPTION
**What does this do?**
* Adds a repeatable field, consultation outcome

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2028

This field was requested for upcoming migration work

**How should this be tested? Do these changes have associated tests?**
Test with the related cspace-ui PR: https://github.com/collectionspace/cspace-ui.js/pull/338

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
The changelog has been updated

**Did someone actually run this code to verify it works?**
@mikejritter tested locally