### PR TITLE
DRYD-1909: Term List > Update Inventory Status Terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,15 @@
 
 * Update default terms to catalog note, legacy data note, and staff note
 
+#### Inventory Status
+
+**Core, Anthro, Bonsai, BotGarden, FCART, Herbarium, LHMC, Materials**
+
+* Update default terms to deaccessions, in storage, missing, off site, on loan, and on display
+
 #### Organization Types
 
-**Core, Bonsai, BotGarden, FCART, Herbarium, LHMC, Materials**
+**Core, Anthro, Bonsai, BotGarden, FCART, Herbarium, LHMC, Materials**
 
 * Add federally-recognized tribe and non-federally-recognized tribe to default terms
 

--- a/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/base-instance-vocabularies.xml
@@ -5,33 +5,12 @@
 		<title-ref>inventorystatus</title-ref>
 		<title>Inventory Status</title>
 		<options>
-			<option id="unknown">unknown</option>
-			<option id="accessionstatusunclear">accession status unclear</option>
-			<option id="accessioned">accessioned</option>
 			<option id="deaccessioned">deaccessioned</option>
-			<option id="destroyed">destroyed</option>
-			<option id="destructiveanalysis">destructive analysis</option>
-			<option id="discarded">discarded</option>
-			<option id="exchanged">exchanged</option>
-			<option id="intendedfortransfer">intended for transfer</option>
-			<option id="irregularmuseumnumber">irregular museum number</option>
+			<option id="instorage">in storage</option>
 			<option id="missing">missing</option>
-			<option id="missingininventory">missing in inventory</option>
-			<option id="notcataloged">not cataloged</option>
-			<option id="notlocated">not located</option>
-			<option id="notreceived">not received</option>
-			<option id="numbernotused">number not used</option>
-			<option id="objectmount">object mount</option>
+			<option id="offsite">off site</option>
 			<option id="onloan">on loan</option>
-			<option id="partiallydeaccessioned">partially deaccessioned</option>
-			<option id="partiallyexchanged">partially exchanged</option>
-			<option id="partiallyrecataloged">partially recataloged</option>
-			<option id="preacquisition">pre acquisition</option>
-			<option id="retired">retired</option>
-			<option id="returnedloanobject">returned loan object</option>
-			<option id="sold">sold</option>
-			<option id="stolen">stolen</option>
-			<option id="transferred">transferred</option>
+			<option id="ondisplay">on display</option>
 		</options>
 	</instance>
 	<instance id="vocab-uocmethods">

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -5,33 +5,12 @@
 		<title-ref>inventorystatus</title-ref>
 		<title>Inventory Status</title>
 		<options>
-			<option id="unknown">unknown</option>
-			<option id="accessionstatusunclear">accession status unclear</option>
-			<option id="accessioned">accessioned</option>
 			<option id="deaccessioned">deaccessioned</option>
-			<option id="destroyed">destroyed</option>
-			<option id="destructiveanalysis">destructive analysis</option>
-			<option id="discarded">discarded</option>
-			<option id="exchanged">exchanged</option>
-			<option id="intendedfortransfer">intended for transfer</option>
-			<option id="irregularmuseumnumber">irregular museum number</option>
+			<option id="instorage">in storage</option>
 			<option id="missing">missing</option>
-			<option id="missingininventory">missing in inventory</option>
-			<option id="notcataloged">not cataloged</option>
-			<option id="notlocated">not located</option>
-			<option id="notreceived">not received</option>
-			<option id="numbernotused">number not used</option>
-			<option id="objectmount">object mount</option>
+			<option id="offsite">off site</option>
 			<option id="onloan">on loan</option>
-			<option id="partiallydeaccessioned">partially deaccessioned</option>
-			<option id="partiallyexchanged">partially exchanged</option>
-			<option id="partiallyrecataloged">partially recataloged</option>
-			<option id="preacquisition">pre acquisition</option>
-			<option id="retired">retired</option>
-			<option id="returnedloanobject">returned loan object</option>
-			<option id="sold">sold</option>
-			<option id="stolen">stolen</option>
-			<option id="transferred">transferred</option>
+			<option id="ondisplay">on display</option>
 		</options>
 	</instance>
 	<instance id="vocab-uocmethods">
@@ -58,7 +37,7 @@
 			<option id="researcher">researcher</option>
 		</options>
 	</instance>
-		<instance id="vocab-uocuserroles">
+	<instance id="vocab-uocuserroles">
 		<web-url>uocuserroles</web-url>
 		<title-ref>uocuserroles</title-ref>
 		<title>Use of Collections User Roles</title>

--- a/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/botgarden/base-instance-vocabularies.xml
@@ -7,33 +7,12 @@
 		<title-ref>inventorystatus</title-ref>
 		<title>Inventory Status</title>
 		<options>
-			<option id="unknown">unknown</option>
-			<option id="accessionstatusunclear">accession status unclear</option>
-			<option id="accessioned">accessioned</option>
 			<option id="deaccessioned">deaccessioned</option>
-			<option id="destroyed">destroyed</option>
-			<option id="destructiveanalysis">destructive analysis</option>
-			<option id="discarded">discarded</option>
-			<option id="exchanged">exchanged</option>
-			<option id="intendedfortransfer">intended for transfer</option>
-			<option id="irregularmuseumnumber">irregular museum number</option>
+			<option id="instorage">in storage</option>
 			<option id="missing">missing</option>
-			<option id="missingininventory">missing in inventory</option>
-			<option id="notcataloged">not cataloged</option>
-			<option id="notlocated">not located</option>
-			<option id="notreceived">not received</option>
-			<option id="numbernotused">number not used</option>
-			<option id="objectmount">object mount</option>
+			<option id="offsite">off site</option>
 			<option id="onloan">on loan</option>
-			<option id="partiallydeaccessioned">partially deaccessioned</option>
-			<option id="partiallyexchanged">partially exchanged</option>
-			<option id="partiallyrecataloged">partially recataloged</option>
-			<option id="preacquisition">pre acquisition</option>
-			<option id="retired">retired</option>
-			<option id="returnedloanobject">returned loan object</option>
-			<option id="sold">sold</option>
-			<option id="stolen">stolen</option>
-			<option id="transferred">transferred</option>
+			<option id="ondisplay">on display</option>
 		</options>
 	</instance>
 	<instance id="vocab-uocmethods">

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -7,33 +7,12 @@
 		<title-ref>inventorystatus</title-ref>
 		<title>Inventory Status</title>
 		<options>
-			<option id="unknown">unknown</option>
-			<option id="accessionstatusunclear">accession status unclear</option>
-			<option id="accessioned">accessioned</option>
 			<option id="deaccessioned">deaccessioned</option>
-			<option id="destroyed">destroyed</option>
-			<option id="destructiveanalysis">destructive analysis</option>
-			<option id="discarded">discarded</option>
-			<option id="exchanged">exchanged</option>
-			<option id="intendedfortransfer">intended for transfer</option>
-			<option id="irregularmuseumnumber">irregular museum number</option>
+			<option id="instorage">in storage</option>
 			<option id="missing">missing</option>
-			<option id="missingininventory">missing in inventory</option>
-			<option id="notcataloged">not cataloged</option>
-			<option id="notlocated">not located</option>
-			<option id="notreceived">not received</option>
-			<option id="numbernotused">number not used</option>
-			<option id="objectmount">object mount</option>
+			<option id="offsite">off site</option>
 			<option id="onloan">on loan</option>
-			<option id="partiallydeaccessioned">partially deaccessioned</option>
-			<option id="partiallyexchanged">partially exchanged</option>
-			<option id="partiallyrecataloged">partially recataloged</option>
-			<option id="preacquisition">pre acquisition</option>
-			<option id="retired">retired</option>
-			<option id="returnedloanobject">returned loan object</option>
-			<option id="sold">sold</option>
-			<option id="stolen">stolen</option>
-			<option id="transferred">transferred</option>
+			<option id="ondisplay">on display</option>
 		</options>
 	</instance>
 	<instance id="vocab-uocmethods">


### PR DESCRIPTION
**What does this do?**
* Updates default terms for inventory status

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1909

This is a request to update the default terms for inventory status to be:
- deaccessioned
- in storage
- missing
- off site
- on loan
- on display

**How should this be tested? Do these changes have associated tests?**
* Rebuild and start a fresh CollectionSpace instance with the following profiles: core, fcart, materials, botgarden
  * Optionally include anthro, herbarium, lhmc
* For each profile, query the vocabulary API to see the updated term list, e.g.
```
curl -u admin@botgarden.collectionspace.org:Administrator 'http://localhost:8180/cspace-services/vocabularies/urn:cspace:name(inventorystatus)/items' -H 'Accept: application/json' 
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
The CHANGELOG has been updated

**Did someone actually run this code to verify it works?**
@mikejritter tested locally against core, botgarden, materials, and fcart