### PR TITLE
DRYD-2009: Add NAGPRA Involved Role terms to FCART

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@
 
 * Update default terms to deaccessions, in storage, missing, off site, on loan, and on display
 
+#### NAGPRA Involved Role
+
+**FCART**
+
+* Added existing default terms to profile
+
 #### Organization Types
 
 **Core, Anthro, Bonsai, BotGarden, FCART, Herbarium, LHMC, Materials**

--- a/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/defaults/extensions/fcart-profile-instance-vocabularies.xml
@@ -1550,4 +1550,15 @@
 			<option id="tribal_representative">tribal representative</option>
 		</options>
 	</instance>
+	<instance id="vocab-nagprainvolvedrole">
+		<web-url>nagprainvolvedrole</web-url>
+		<title-ref>nagprainvolvedrole</title-ref>
+		<title>NAGPRA Involved Role</title>
+		<options>
+			<option id="tribal_rep">tribal representative</option>
+			<option id="museum_rep">museum representative</option>
+			<option id="consultant">consultant</option>
+			<option id="lineal_descendant">lineal descendant</option>
+		</options>
+	</instance>
 </instances>


### PR DESCRIPTION
**What does this do?**
* Adds the NAGPRA Involved Role term list to FCART 

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2009

When adding the parties involved group of fields, we decided to also add it to LHMC and FCART. When testing, we realized that FCART does not have the term list needed for the group of fields.

**How should this be tested? Do these changes have associated tests?**
* Build collectionspace with the fcart tenant enabled
* Check that the term list exists, e.g.
```
curl -u admin@fcart.collectionspace.org:Administrator 'http://localhost:8180/cspace-services/vocabularies/urn:cspace:name(nagprainvolvedrole)/items' -H 'Accept: application/json'
```
* It would be good to test in the FCART profile plugin as well

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
The changelog has been updated

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local FCART instance