### PR TITLE
Prepare 8.3.0-RC.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<name>Root</name>
 
 	<properties>
-		<revision>8.3.0-RC.1</revision>
+		<revision>8.3.0-RC.2</revision>
 		<cspace.services.version>${revision}</cspace.services.version>
 		<temp.war.location>${basedir}/tmp</temp.war.location>
 		<cspace.tool.csmake>csmake</cspace.tool.csmake>


### PR DESCRIPTION
**What does this do?**
* Bumps the version to 8.3.0-RC.2

**Why are we doing this? (with JIRA link)**
No jira

This sets the version for the second release candidate

**How should this be tested? Do these changes have associated tests?**
* Deploy with the services PR

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@mikejritter deployed locally