### PR TITLE
 DRYD-2043: Add nagprainvolvedrole to materials and publicart 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 
 #### NAGPRA Involved Role
 
-**FCART**
+**FCART, Materials, PublicArt**
 
 * Added existing default terms to profile
 

--- a/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/materials/base-instance-vocabularies.xml
@@ -1492,4 +1492,15 @@
 			<option id="tribal_representative">tribal representative</option>
 		</options>
 	</instance>
+	<instance id="vocab-nagprainvolvedrole">
+		<web-url>nagprainvolvedrole</web-url>
+		<title-ref>nagprainvolvedrole</title-ref>
+		<title>NAGPRA Involved Role</title>
+		<options>
+			<option id="tribal_rep">tribal representative</option>
+			<option id="museum_rep">museum representative</option>
+			<option id="consultant">consultant</option>
+			<option id="lineal_descendant">lineal descendant</option>
+		</options>
+	</instance>
 </instances>

--- a/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/publicart/base-instance-vocabularies.xml
@@ -2107,4 +2107,15 @@
 			<option id="tribal_representative">tribal representative</option>
 		</options>
 	</instance>
+	<instance id="vocab-nagprainvolvedrole">
+		<web-url>nagprainvolvedrole</web-url>
+		<title-ref>nagprainvolvedrole</title-ref>
+		<title>NAGPRA Involved Role</title>
+		<options>
+			<option id="tribal_rep">tribal representative</option>
+			<option id="museum_rep">museum representative</option>
+			<option id="consultant">consultant</option>
+			<option id="lineal_descendant">lineal descendant</option>
+		</options>
+	</instance>
 </instances>


### PR DESCRIPTION
**What does this do?**
* Adds nagprainvolvedrole to materials and publicart

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2043

This term list is needed for the changes which were made to the deaccession procedure. 

**How should this be tested? Do these changes have associated tests?**
* Enable to materials and publicart profiles
* Rebuild and start collectionspace
* Query for the new term list, e.g.
```
curl -u admin@materials.collectionspace.org:Administrator 'http://localhost:8180/cspace-services/vocabularies/urn:cspace:name(nagprainvolvedrole)/items' -H 'Accept: application/json' | jq .
```

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
The changelog was updated

**Did someone actually run this code to verify it works?**
@mikejritter is currently testing locally...