### PR TITLE
DRYD-2124: Set Release to JDK 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<properties>
 		<revision>9.0.0-SNAPSHOT</revision>
 		<cspace.services.version>${revision}</cspace.services.version>
-		<java.version>17</java.version>
+		<java.version>21</java.version>
 		<temp.war.location>${basedir}/tmp</temp.war.location>
 		<cspace.tool.csmake>csmake</cspace.tool.csmake>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
**What does this do?**
Sets the release to target JDK 21

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2124

As part of the upgrade we wanted to see what version of the JDK we should land on. After research and some testing we decided on JDK 21.

**How should this be tested? Do these changes have associated tests?**
* Follow the directions in https://github.com/collectionspace/services/pull/547

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
The release/build docs need to be updated

**Did someone actually run this code to verify it works?**
@mikejritter tested locally

**Have any new security vulnerabilities been handled?**
n/a
