### PR TITLE
DRYD-2002: Settings for Password Requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tomcat-main/plugins/
 tomcat-main/nb-configuration.xml
 tomcat-main/nbactions-debug.xml
 cspi-schema/dumpedTrees/
+cspi-schema/logs/
 *.bak
 target/
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 9.0.0
 
+### Build
+
+* Update to JDK 21
+
+### Settings
+
+* Add password complexity requirements to tenant settings.xml
+
 ### CollectionObject
 
 * Add home location group `homeLocationGroupList/homeLocationGroup`

--- a/cspi-installation/src/main/java/org/collectionspace/chain/installation/ServiceBindingsGeneration.java
+++ b/cspi-installation/src/main/java/org/collectionspace/chain/installation/ServiceBindingsGeneration.java
@@ -502,7 +502,7 @@ public class ServiceBindingsGeneration {
 			root.addElement(new QName("requireDigit", nstenant))
 				.addText(String.valueOf(passwordComplexityData.requireDigit()));
 
-			// passwordComplexity/requireLowerCase
+			// passwordComplexity/requireSpecial
 			root.addElement(new QName("requireSpecial", nstenant))
 				.addText(String.valueOf(passwordComplexityData.requireSpecial()));
 		}

--- a/cspi-installation/src/main/java/org/collectionspace/chain/installation/ServiceBindingsGeneration.java
+++ b/cspi-installation/src/main/java/org/collectionspace/chain/installation/ServiceBindingsGeneration.java
@@ -478,11 +478,11 @@ public class ServiceBindingsGeneration {
 	private void makePasswordComplexityBindings(Element tenantBindings) {
 		PasswordComplexityData passwordComplexityData = spec.getPasswordComplexityData();
 		if (passwordComplexityData != null && passwordComplexityData.isEnabled()) {
-			final var root = tenantBindings.addElement(new QName("passwordComplexity", nstenant));
+			final var root = tenantBindings.addElement(new QName("passwordRequirementConfig", nstenant));
 
-			// passwordComplexity/allowWhitespace
-			root.addElement(new QName("allowWhitespace", nstenant))
-				.addText(String.valueOf(passwordComplexityData.isAllowWhitespace()));
+			// passwordComplexity/enabled
+			root.addElement(new QName("enabled", nstenant))
+				.addText(String.valueOf(passwordComplexityData.isEnabled()));
 
 			// passwordComplexity/minLength
 			passwordComplexityData.getMinLength().ifPresent(minLength ->
@@ -490,68 +490,21 @@ public class ServiceBindingsGeneration {
 					.addText(String.valueOf(minLength))
 			);
 
-			// passwordComplexity/characterRules/{minLowerCase,minUpperCase,minDigits,minSpecial}
-			Element characterRuleParent;
-			final var minLowerCase = passwordComplexityData.getMinLowerCase();
-			final var minUpperCase = passwordComplexityData.getMinUpperCase();
-			final var minDigits = passwordComplexityData.getMinDigits();
-			final var minSpecial = passwordComplexityData.getMinSpecial();
-			final var hasCharacterRules = minLowerCase.isPresent() ||
-										  minUpperCase.isPresent() ||
-										  minDigits.isPresent() ||
-										  minSpecial.isPresent();
-			if (hasCharacterRules) {
-				characterRuleParent = root.addElement(new QName("characterRules", nstenant));
-				passwordComplexityData.getMinLowerCase().ifPresent(minimum -> {
-					characterRuleParent.addElement(new QName("minLowerCase", nstenant))
-									   .addText(String.valueOf(minimum));
-				});
-				passwordComplexityData.getMinUpperCase().ifPresent(minimum -> {
-					characterRuleParent.addElement(new QName("minUpperCase", nstenant))
-									   .addText(String.valueOf(minimum));
-				});
-				passwordComplexityData.getMinDigits().ifPresent(minimum -> {
-					characterRuleParent.addElement(new QName("minDigits", nstenant))
-									   .addText(String.valueOf(minimum));
-				});
-				passwordComplexityData.getMinSpecial().ifPresent(minimum -> {
-					characterRuleParent.addElement(new QName("minSpecial", nstenant))
-									   .addText(String.valueOf(minimum));
-				});
-			}
+			// passwordComplexity/requireLowerCase
+			root.addElement(new QName("requireLowerCase", nstenant))
+				.addText(String.valueOf(passwordComplexityData.requireLowerCase()));
 
-			// passwordComplexity/characterClassRules
-			final var minClassesRequired = passwordComplexityData.getMinCharacterClasses();
-			final var classesRequired = passwordComplexityData.getCharacterClasses();
-			minClassesRequired.ifPresent(classesRequiredInt -> {
-				if (classesRequiredInt <= classesRequired.size()) {
-					final var ccElement = root.addElement(new QName("characterClassRules", nstenant));
-					ccElement.addElement(new QName("minClassesRequired", nstenant))
-							 .addText(String.valueOf(classesRequiredInt));
-					ccElement.addElement(new QName("classesRequired", nstenant))
-							 .addText(String.join(",", classesRequired));
-				} else {
-					log.error("Invalid character class rule found: require {} of {}",
-							  classesRequiredInt, classesRequired);
-				}
-			});
+			// passwordComplexity/requireUpperCase
+			root.addElement(new QName("requireUpperCase", nstenant))
+				.addText(String.valueOf(passwordComplexityData.requireUpperCase()));
 
-			// passwordComplexity/illegalSequences/illegalSequence
-			final var illegalSequences = passwordComplexityData.getIllegalSequences();
-			if (!illegalSequences.isEmpty()) {
-				final var isRoot = root.addElement(new QName("illegalSequences", nstenant));
-				illegalSequences.forEach(illegalSequence -> {
-					if (illegalSequence.getCharacterClass() != null && !illegalSequence.getCharacterClass().isEmpty()) {
-						final var sequenceElement = isRoot.addElement(new QName("illegalSequence", nstenant));
-						sequenceElement.addElement(new QName("characterClass", nstenant))
-									   .addText(illegalSequence.getCharacterClass());
-						sequenceElement.addElement(new QName("length", nstenant))
-									   .addText(String.valueOf(illegalSequence.getLength()));
-					} else {
-						log.error("Null or empty character class found for sequence; validate settings.xml");
-					}
-				});
-			}
+			// passwordComplexity/requireDigit
+			root.addElement(new QName("requireDigit", nstenant))
+				.addText(String.valueOf(passwordComplexityData.requireDigit()));
+
+			// passwordComplexity/requireLowerCase
+			root.addElement(new QName("requireSpecial", nstenant))
+				.addText(String.valueOf(passwordComplexityData.requireSpecial()));
 		}
 	}
 

--- a/cspi-installation/src/main/java/org/collectionspace/chain/installation/ServiceBindingsGeneration.java
+++ b/cspi-installation/src/main/java/org/collectionspace/chain/installation/ServiceBindingsGeneration.java
@@ -481,7 +481,7 @@ public class ServiceBindingsGeneration {
 			final var root = tenantBindings.addElement(new QName("passwordComplexity", nstenant));
 
 			// passwordComplexity/allowWhitespace
-			root.addElement(new QName("allowWhitespace"))
+			root.addElement(new QName("allowWhitespace", nstenant))
 				.addText(String.valueOf(passwordComplexityData.isAllowWhitespace()));
 
 			// passwordComplexity/minLength
@@ -525,7 +525,7 @@ public class ServiceBindingsGeneration {
 			final var classesRequired = passwordComplexityData.getCharacterClasses();
 			minClassesRequired.ifPresent(classesRequiredInt -> {
 				if (classesRequiredInt <= classesRequired.size()) {
-					final var ccElement = root.addElement(new QName("characterClassRules"));
+					final var ccElement = root.addElement(new QName("characterClassRules", nstenant));
 					ccElement.addElement(new QName("minClassesRequired", nstenant))
 							 .addText(String.valueOf(classesRequiredInt));
 					ccElement.addElement(new QName("classesRequired", nstenant))

--- a/cspi-installation/src/main/java/org/collectionspace/chain/installation/ServiceBindingsGeneration.java
+++ b/cspi-installation/src/main/java/org/collectionspace/chain/installation/ServiceBindingsGeneration.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
 
+import org.apache.commons.io.FileUtils;
 import org.collectionspace.chain.csp.persistence.services.TenantSpec;
 import org.collectionspace.chain.csp.persistence.services.TenantSpec.RemoteClient;
 import org.collectionspace.chain.csp.schema.EmailData;
@@ -16,6 +17,7 @@ import org.collectionspace.chain.csp.schema.FieldSet;
 import org.collectionspace.chain.csp.schema.Group;
 import org.collectionspace.chain.csp.schema.Instance;
 import org.collectionspace.chain.csp.schema.Option;
+import org.collectionspace.chain.csp.schema.PasswordComplexityData;
 import org.collectionspace.chain.csp.schema.Record;
 import org.collectionspace.chain.csp.schema.Repeat;
 import org.collectionspace.chain.csp.schema.Spec;
@@ -31,7 +33,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.commons.io.FileUtils;
 
 public class ServiceBindingsGeneration {
 	private static final Logger log = LoggerFactory.getLogger(ServiceBindingsGeneration.class);
@@ -199,6 +200,8 @@ public class ServiceBindingsGeneration {
 
 		// Set the bindings for email notifications
 		makeEmailBindings(ele);
+
+		makePasswordComplexityBindings(ele);
 
 		makeUiBindings(ele);
 
@@ -452,7 +455,6 @@ public class ServiceBindingsGeneration {
 				// into seconds; otherwise, ignore the 'daysvalid' field and use the configured 'tokenExpirationSeconds' value.
 				//
 				Element ele = passwordResetElement.addElement(new QName("tokenExpirationSeconds", nstenant));
-				Integer secondsValid = emailData.getTokenExpirationDays() * 60 * 60 * 24; // Convert days into seconds
 				ele.addText(emailData.getTokenExpirationSeconds().toString());
 			}
 
@@ -469,6 +471,86 @@ public class ServiceBindingsGeneration {
 			if (emailData.getPasswordResetMessage() != null) {
 				Element ele = passwordResetElement.addElement(new QName("message", nstenant));
 				ele.addText(emailData.getPasswordResetMessage());
+			}
+		}
+	}
+
+	private void makePasswordComplexityBindings(Element tenantBindings) {
+		PasswordComplexityData passwordComplexityData = spec.getPasswordComplexityData();
+		if (passwordComplexityData != null && passwordComplexityData.isEnabled()) {
+			final var root = tenantBindings.addElement(new QName("passwordComplexity", nstenant));
+
+			// passwordComplexity/allowWhitespace
+			root.addElement(new QName("allowWhitespace"))
+				.addText(String.valueOf(passwordComplexityData.isAllowWhitespace()));
+
+			// passwordComplexity/minLength
+			passwordComplexityData.getMinLength().ifPresent(minLength ->
+				root.addElement(new QName("minLength", nstenant))
+					.addText(String.valueOf(minLength))
+			);
+
+			// passwordComplexity/characterRules/{minLowerCase,minUpperCase,minDigits,minSpecial}
+			Element characterRuleParent;
+			final var minLowerCase = passwordComplexityData.getMinLowerCase();
+			final var minUpperCase = passwordComplexityData.getMinUpperCase();
+			final var minDigits = passwordComplexityData.getMinDigits();
+			final var minSpecial = passwordComplexityData.getMinSpecial();
+			final var hasCharacterRules = minLowerCase.isPresent() ||
+										  minUpperCase.isPresent() ||
+										  minDigits.isPresent() ||
+										  minSpecial.isPresent();
+			if (hasCharacterRules) {
+				characterRuleParent = root.addElement(new QName("characterRules", nstenant));
+				passwordComplexityData.getMinLowerCase().ifPresent(minimum -> {
+					characterRuleParent.addElement(new QName("minLowerCase", nstenant))
+									   .addText(String.valueOf(minimum));
+				});
+				passwordComplexityData.getMinUpperCase().ifPresent(minimum -> {
+					characterRuleParent.addElement(new QName("minUpperCase", nstenant))
+									   .addText(String.valueOf(minimum));
+				});
+				passwordComplexityData.getMinDigits().ifPresent(minimum -> {
+					characterRuleParent.addElement(new QName("minDigits", nstenant))
+									   .addText(String.valueOf(minimum));
+				});
+				passwordComplexityData.getMinSpecial().ifPresent(minimum -> {
+					characterRuleParent.addElement(new QName("minSpecial", nstenant))
+									   .addText(String.valueOf(minimum));
+				});
+			}
+
+			// passwordComplexity/characterClassRules
+			final var minClassesRequired = passwordComplexityData.getMinCharacterClasses();
+			final var classesRequired = passwordComplexityData.getCharacterClasses();
+			minClassesRequired.ifPresent(classesRequiredInt -> {
+				if (classesRequiredInt <= classesRequired.size()) {
+					final var ccElement = root.addElement(new QName("characterClassRules"));
+					ccElement.addElement(new QName("minClassesRequired", nstenant))
+							 .addText(String.valueOf(classesRequiredInt));
+					ccElement.addElement(new QName("classesRequired", nstenant))
+							 .addText(String.join(",", classesRequired));
+				} else {
+					log.error("Invalid character class rule found: require {} of {}",
+							  classesRequiredInt, classesRequired);
+				}
+			});
+
+			// passwordComplexity/illegalSequences/illegalSequence
+			final var illegalSequences = passwordComplexityData.getIllegalSequences();
+			if (!illegalSequences.isEmpty()) {
+				final var isRoot = root.addElement(new QName("illegalSequences", nstenant));
+				illegalSequences.forEach(illegalSequence -> {
+					if (illegalSequence.getCharacterClass() != null && !illegalSequence.getCharacterClass().isEmpty()) {
+						final var sequenceElement = isRoot.addElement(new QName("illegalSequence", nstenant));
+						sequenceElement.addElement(new QName("characterClass", nstenant))
+									   .addText(illegalSequence.getCharacterClass());
+						sequenceElement.addElement(new QName("length", nstenant))
+									   .addText(String.valueOf(illegalSequence.getLength()));
+					} else {
+						log.error("Null or empty character class found for sequence; validate settings.xml");
+					}
+				});
 			}
 		}
 	}

--- a/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/PasswordComplexityData.java
+++ b/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/PasswordComplexityData.java
@@ -1,8 +1,5 @@
 package org.collectionspace.chain.csp.schema;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 import org.collectionspace.chain.csp.config.ReadOnlySection;

--- a/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/PasswordComplexityData.java
+++ b/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/PasswordComplexityData.java
@@ -9,33 +9,21 @@ import org.collectionspace.chain.csp.config.ReadOnlySection;
 
 public class PasswordComplexityData {
     final boolean enabled;
-    final boolean allowWhitespace;
 
     final Integer minLength;
-    final Integer minLowerCase;
-    final Integer minUpperCase;
-    final Integer minDigits;
-    final Integer minSpecial;
-
-    final Integer minCharacterClasses;
-    final List<String> characterClasses;
-
-    final List<IllegalSequence> illegalSequences = new ArrayList<>();
+    final boolean requireLowerCase;
+    final boolean requireUpperCase;
+    final boolean requireDigit;
+    final boolean requireSpecial;
 
     public PasswordComplexityData(ReadOnlySection section) {
         enabled = Boolean.parseBoolean((String) section.getValue("/enabled"));
-        allowWhitespace = Boolean.parseBoolean((String) section.getValue("/allow-whitespace"));
 
         minLength = parseIntFromSection(section, "/min-length");
-        minLowerCase = parseIntFromSection(section, "/character-rules/min-lower-case");
-        minUpperCase = parseIntFromSection(section, "/character-rules/min-upper-case");
-        minDigits = parseIntFromSection(section, "/character-rules/min-digit");
-        minSpecial = parseIntFromSection(section, "/character-rules/min-special");
-
-        minCharacterClasses = parseIntFromSection(section, "/character-class-rules/min-required");
-        var characterClassesStr = (String) section.getValue("/character-class-rules/character-classes");
-        characterClasses = characterClassesStr != null ? Arrays.asList(characterClassesStr.split(","))
-                                                       : new ArrayList<>();
+        requireLowerCase = Boolean.parseBoolean((String) section.getValue("/require-lower-case"));
+        requireUpperCase = Boolean.parseBoolean((String) section.getValue("/require-upper-case"));
+        requireDigit = Boolean.parseBoolean((String) section.getValue("/require-digit"));
+        requireSpecial = Boolean.parseBoolean((String) section.getValue("/require-special"));
     }
 
     private Integer parseIntFromSection(ReadOnlySection section, String path) {
@@ -43,67 +31,28 @@ public class PasswordComplexityData {
         return asString == null ? null : Integer.parseInt(asString);
     }
 
-    public void addIllegalSequence(IllegalSequence sequence) {
-        illegalSequences.add(sequence);
-    }
-
     public boolean isEnabled() {
         return enabled;
     }
 
-    public boolean isAllowWhitespace() {
-        return allowWhitespace;
+    public boolean requireLowerCase() {
+        return requireLowerCase;
+    }
+
+    public boolean requireUpperCase() {
+        return requireUpperCase;
+    }
+
+    public boolean requireDigit() {
+        return requireDigit;
+    }
+
+    public boolean requireSpecial() {
+        return requireSpecial;
     }
 
     public Optional<Integer> getMinLength() {
         return Optional.ofNullable(minLength);
     }
 
-    public Optional<Integer> getMinLowerCase() {
-        return Optional.ofNullable(minLowerCase);
-    }
-
-    public Optional<Integer> getMinUpperCase() {
-        return Optional.ofNullable(minUpperCase);
-    }
-
-    public Optional<Integer> getMinDigits() {
-        return Optional.ofNullable(minDigits);
-    }
-
-    public Optional<Integer> getMinSpecial() {
-        return Optional.ofNullable(minSpecial);
-    }
-
-    public Optional<Integer> getMinCharacterClasses() {
-        return Optional.ofNullable(minCharacterClasses);
-    }
-
-    public List<String> getCharacterClasses() {
-        return characterClasses;
-    }
-
-    public List<IllegalSequence> getIllegalSequences() {
-        return illegalSequences;
-    }
-
-    public static class IllegalSequence {
-        final String characterClass;
-        final int length;
-
-        public IllegalSequence(ReadOnlySection section) {
-            this.characterClass = (String) section.getValue("/character-class");
-
-            String lengthStr = (String) section.getValue("/length");
-            this.length = lengthStr != null ? Integer.parseInt(lengthStr) : 6;
-        }
-
-        public String getCharacterClass() {
-            return characterClass;
-        }
-
-        public int getLength() {
-            return length;
-        }
-    }
 }

--- a/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/PasswordComplexityData.java
+++ b/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/PasswordComplexityData.java
@@ -1,0 +1,109 @@
+package org.collectionspace.chain.csp.schema;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.collectionspace.chain.csp.config.ReadOnlySection;
+
+public class PasswordComplexityData {
+    final boolean enabled;
+    final boolean allowWhitespace;
+
+    final Integer minLength;
+    final Integer minLowerCase;
+    final Integer minUpperCase;
+    final Integer minDigits;
+    final Integer minSpecial;
+
+    final Integer minCharacterClasses;
+    final List<String> characterClasses;
+
+    final List<IllegalSequence> illegalSequences = new ArrayList<>();
+
+    public PasswordComplexityData(ReadOnlySection section) {
+        enabled = Boolean.parseBoolean((String) section.getValue("/enabled"));
+        allowWhitespace = Boolean.parseBoolean((String) section.getValue("/allow-whitespace"));
+
+        minLength = parseIntFromSection(section, "/min-length");
+        minLowerCase = parseIntFromSection(section, "/character-rules/min-lower-case");
+        minUpperCase = parseIntFromSection(section, "/character-rules/min-upper-case");
+        minDigits = parseIntFromSection(section, "/character-rules/min-digit");
+        minSpecial = parseIntFromSection(section, "/character-rules/min-special");
+
+        minCharacterClasses = parseIntFromSection(section, "/character-class-rules/min-required");
+        var characterClassesStr = (String) section.getValue("/character-class-rules/character-classes");
+        characterClasses = characterClassesStr != null ? Arrays.asList(characterClassesStr.split(","))
+                                                       : new ArrayList<>();
+    }
+
+    private Integer parseIntFromSection(ReadOnlySection section, String path) {
+        final var asString = (String) section.getValue(path);
+        return asString == null ? null : Integer.parseInt(asString);
+    }
+
+    public void addIllegalSequence(IllegalSequence sequence) {
+        illegalSequences.add(sequence);
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public boolean isAllowWhitespace() {
+        return allowWhitespace;
+    }
+
+    public Optional<Integer> getMinLength() {
+        return Optional.ofNullable(minLength);
+    }
+
+    public Optional<Integer> getMinLowerCase() {
+        return Optional.ofNullable(minLowerCase);
+    }
+
+    public Optional<Integer> getMinUpperCase() {
+        return Optional.ofNullable(minUpperCase);
+    }
+
+    public Optional<Integer> getMinDigits() {
+        return Optional.ofNullable(minDigits);
+    }
+
+    public Optional<Integer> getMinSpecial() {
+        return Optional.ofNullable(minSpecial);
+    }
+
+    public Optional<Integer> getMinCharacterClasses() {
+        return Optional.ofNullable(minCharacterClasses);
+    }
+
+    public List<String> getCharacterClasses() {
+        return characterClasses;
+    }
+
+    public List<IllegalSequence> getIllegalSequences() {
+        return illegalSequences;
+    }
+
+    public static class IllegalSequence {
+        final String characterClass;
+        final int length;
+
+        public IllegalSequence(ReadOnlySection section) {
+            this.characterClass = (String) section.getValue("/character-class");
+
+            String lengthStr = (String) section.getValue("/length");
+            this.length = lengthStr != null ? Integer.parseInt(lengthStr) : 6;
+        }
+
+        public String getCharacterClass() {
+            return characterClass;
+        }
+
+        public int getLength() {
+            return length;
+        }
+    }
+}

--- a/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/Spec.java
+++ b/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/Spec.java
@@ -124,19 +124,6 @@ public class Spec implements CSP, Configurable {
 						  }
 					  });
 
-		rules.addRule(SECTION_PREFIX + "password-complexity",
-					  new String[] {"illegal-sequences", "illegal-sequence"},
-					  SECTION_PREFIX + "illegal-sequence",
-					  null,
-					  new RuleTarget() {
-						  @Override
-						  public Object populate(Object parent, ReadOnlySection section) {
-							  final var sequence = new PasswordComplexityData.IllegalSequence(section);
-							  passwordComplexityData.addIllegalSequence(sequence);
-							  return this;
-						  }
-					  });
-
 
 		rules.addRule(SECTIONED,new String[]{"ui"},SECTION_PREFIX+"ui",null,new RuleTarget(){
 			@Override

--- a/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/Spec.java
+++ b/cspi-schema/src/main/java/org/collectionspace/chain/csp/schema/Spec.java
@@ -62,6 +62,7 @@ public class Spec implements CSP, Configurable {
 	private EmailData ed;
 	private AdminData adminData;
 	private UiData uiData;
+	private PasswordComplexityData passwordComplexityData;
 
 	@Override
 	public String getName() { return "schema"; }
@@ -113,6 +114,29 @@ public class Spec implements CSP, Configurable {
 				return this;
 			}
 		});
+
+		rules.addRule(SECTIONED, new String[] {"password-complexity"}, SECTION_PREFIX + "password-complexity", null,
+					  new RuleTarget() {
+						  @Override
+						  public Object populate(Object parent, ReadOnlySection section) {
+							  passwordComplexityData = new PasswordComplexityData(section);
+							  return this;
+						  }
+					  });
+
+		rules.addRule(SECTION_PREFIX + "password-complexity",
+					  new String[] {"illegal-sequences", "illegal-sequence"},
+					  SECTION_PREFIX + "illegal-sequence",
+					  null,
+					  new RuleTarget() {
+						  @Override
+						  public Object populate(Object parent, ReadOnlySection section) {
+							  final var sequence = new PasswordComplexityData.IllegalSequence(section);
+							  passwordComplexityData.addIllegalSequence(sequence);
+							  return this;
+						  }
+					  });
+
 
 		rules.addRule(SECTIONED,new String[]{"ui"},SECTION_PREFIX+"ui",null,new RuleTarget(){
 			@Override
@@ -443,6 +467,10 @@ public class Spec implements CSP, Configurable {
 			}
 		});
 
+	}
+
+	public PasswordComplexityData getPasswordComplexityData() {
+		return passwordComplexityData;
 	}
 
 	public EmailData getEmailData() { return ed.getEmailData(); }

--- a/cspi-services/src/main/java/org/collectionspace/chain/csp/persistence/services/ServicesStorageGenerator.java
+++ b/cspi-services/src/main/java/org/collectionspace/chain/csp/persistence/services/ServicesStorageGenerator.java
@@ -155,7 +155,7 @@ public class ServicesStorageGenerator extends SplittingStorage implements Contex
 				String tenantId = (String)milestone.getValue("/tenantId");
 				String tenantName = (String)milestone.getValue("/tenantName");
 
-				RemoteClient remoteClient = tenantSpec.new RemoteClient(name, url, username, password, ssl, auth, tenantId, tenantName);
+				RemoteClient remoteClient = new TenantSpec.RemoteClient(name, url, username, password, ssl, auth, tenantId, tenantName);
 				tenantSpec.addRemoteClient(remoteClient);
 
 				return this;

--- a/cspi-services/src/main/java/org/collectionspace/chain/csp/persistence/services/TenantSpec.java
+++ b/cspi-services/src/main/java/org/collectionspace/chain/csp/persistence/services/TenantSpec.java
@@ -51,7 +51,7 @@ public class TenantSpec {
 	private Set<String> defaultlanguages = new LinkedHashSet<String>();
 	private Set<String> defaultdateformats = new LinkedHashSet<String>();
 	
-	public class RemoteClient {
+	public static class RemoteClient {
 		private String name;
 		private String url;
 		private String user;

--- a/pom.xml
+++ b/pom.xml
@@ -283,33 +283,6 @@
 			        </execution>
 			    </executions>
 			</plugin>
-			<plugin>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.8</version>
-				<executions>
-					<execution>
-						<id>check-environment-vars</id>
-						<phase>validate</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
-						<configuration>
-							<tasks>
-								<!-- <fail unless="${env.JEE_PORT}"
-									message="Required environment variable JEE_PORT has not been set.  Use 8180 as a default value." /> -->
-								<property environment="env"></property>
-								<fail message="Failed to set JEE_PORT environment variable.  Set it using 8180 as a default value.">
-									<condition>
-										<not>
-											<isset property="env.JEE_PORT"></isset>
-										</not>
-									</condition>
-								</fail>
-							</tasks>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/tomcat-main/src/main/resources/defaults/settings.xml
+++ b/tomcat-main/src/main/resources/defaults/settings.xml
@@ -48,31 +48,10 @@
     <password-complexity>
         <enabled>true</enabled>
         <min-length>6</min-length>
-        <character-rules>
-            <min-lower-case>1</min-lower-case>
-            <min-upper-case>1</min-upper-case>
-            <min-digit>1</min-digit>
-            <min-special>1</min-special>
-        </character-rules>
-        <character-class-rules>
-          <min-required>4</min-required>
-          <character-classes>lowercase,uppercase,digit,special</character-classes>
-        </character-class-rules>
-        <illegal-sequences>
-            <illegal-sequence>
-                <character-class>alphabetical</character-class>
-                <length>5</length>
-            </illegal-sequence>
-            <illegal-sequence>
-                <character-class>numeric</character-class>
-                <length>5</length>
-            </illegal-sequence>
-            <illegal-sequence>
-                <character-class>qwerty</character-class>
-                <length>5</length>
-            </illegal-sequence>
-        </illegal-sequences>
-        <allow-whitespace>false</allow-whitespace>
+        <require-lower-case>true</require-lower-case>
+        <require-upper-case>true</require-upper-case>
+        <require-digit>true</require-digit>
+        <require-special>true</require-special>
     </password-complexity>
     <persistence>
         <service>

--- a/tomcat-main/src/main/resources/defaults/settings.xml
+++ b/tomcat-main/src/main/resources/defaults/settings.xml
@@ -46,6 +46,7 @@
         </passwordreset>
     </email>
     <password-complexity>
+        <enabled>true</enabled>
         <min-length>6</min-length>
         <character-rules>
             <min-lower-case>1</min-lower-case>
@@ -53,6 +54,10 @@
             <min-digit>1</min-digit>
             <min-special>1</min-special>
         </character-rules>
+        <character-class-rules>
+          <min-required>4</min-required>
+          <character-classes>lowercase,uppercase,digit,special</character-classes>
+        </character-class-rules>
         <illegal-sequences>
             <illegal-sequence>
                 <character-class>alphabetical</character-class>

--- a/tomcat-main/src/main/resources/defaults/settings.xml
+++ b/tomcat-main/src/main/resources/defaults/settings.xml
@@ -4,23 +4,23 @@
         <password>Administrator</password>
         <tenant>1</tenant>
         <tenantname>core</tenantname>
-		<cookievalidformins>60</cookievalidformins>
-		<!--
-			termLists, autocomplete instance lists, specs, and schemas,
-			static UI elements, etc will cache for a month (60*60*24*30) by default
-		-->
+        <cookievalidformins>60</cookievalidformins>
+        <!--
+            termLists, autocomplete instance lists, specs, and schemas,
+            static UI elements, etc will cache for a month (60*60*24*30) by default
+        -->
         <termlist-cache-timeout>2592000</termlist-cache-timeout>
         <autocompletelist-cache-timeout>2592000</autocompletelist-cache-timeout>
         <reportlist-cache-timeout>2592000</reportlist-cache-timeout>
-		<!-- This is for user-uploaded media, not static UI images -->
+        <!-- This is for user-uploaded media, not static UI images -->
         <uploaded-media-cache-timeout>2592000</uploaded-media-cache-timeout>
         <uispecschema-cache-timeout>2592000</uispecschema-cache-timeout>
         <ui-html-cache-timeout>2592000</ui-html-cache-timeout>
         <ui-css-cache-timeout>2592000</ui-css-cache-timeout>
-		<ui-js-cache-timeout>2592000</ui-js-cache-timeout>
-		<!-- This is for static UI images like icons, not uploaded images -->
-		<ui-media-cache-timeout>2592000</ui-media-cache-timeout>
-		<!-- This is for the message bundles properties -->
+        <ui-js-cache-timeout>2592000</ui-js-cache-timeout>
+        <!-- This is for static UI images like icons, not uploaded images -->
+        <ui-media-cache-timeout>2592000</ui-media-cache-timeout>
+        <!-- This is for the message bundles properties -->
         <ui-props-cache-timeout>2592000</ui-props-cache-timeout>
     </admin>
     <email>
@@ -43,14 +43,14 @@
             </token>
             <subject>CollectionSpace Password reset request</subject>
             <message>Hello {{greeting}},\n\r\n\rYou've started the process to reset your CollectionSpace account password. To finish resetting your password, go to the Reset Password page {{link}} on CollectionSpace.\n\r\n\rIf clicking the link doesn't work, copy and paste the following link into your browser address bar and click Go.\n\r\n\r{{link}}\n\r Thanks,\n\r\n\r CollectionSpace Administrator\n\r\n\rPlease do not reply to this email. This mailbox is not monitored and you will not receive a response. For assistance, contact your CollectionSpace Administrator directly.</message>
-		</passwordreset>
+        </passwordreset>
     </email>
     <persistence>
         <service>
             <url>http://localhost:@JEE_PORT@/cspace-services</url>
-			<config-tenant></config-tenant>
-			<config-bindings></config-bindings>
-			<ims-url>/collectionspace/tenant/core/</ims-url> <!-- XXX should be in separate IMS section -->
+            <config-tenant></config-tenant>
+            <config-bindings></config-bindings>
+            <ims-url>/collectionspace/tenant/core/</ims-url> <!-- XXX should be in separate IMS section -->
         </service>
     </persistence>
 </settings>

--- a/tomcat-main/src/main/resources/defaults/settings.xml
+++ b/tomcat-main/src/main/resources/defaults/settings.xml
@@ -46,7 +46,7 @@
         </passwordreset>
     </email>
     <password-complexity>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
         <min-length>6</min-length>
         <require-lower-case>true</require-lower-case>
         <require-upper-case>true</require-upper-case>

--- a/tomcat-main/src/main/resources/defaults/settings.xml
+++ b/tomcat-main/src/main/resources/defaults/settings.xml
@@ -45,6 +45,30 @@
             <message>Hello {{greeting}},\n\r\n\rYou've started the process to reset your CollectionSpace account password. To finish resetting your password, go to the Reset Password page {{link}} on CollectionSpace.\n\r\n\rIf clicking the link doesn't work, copy and paste the following link into your browser address bar and click Go.\n\r\n\r{{link}}\n\r Thanks,\n\r\n\r CollectionSpace Administrator\n\r\n\rPlease do not reply to this email. This mailbox is not monitored and you will not receive a response. For assistance, contact your CollectionSpace Administrator directly.</message>
         </passwordreset>
     </email>
+    <password-complexity>
+        <min-length>6</min-length>
+        <character-rules>
+            <min-lower-case>1</min-lower-case>
+            <min-upper-case>1</min-upper-case>
+            <min-digit>1</min-digit>
+            <min-special>1</min-special>
+        </character-rules>
+        <illegal-sequences>
+            <illegal-sequence>
+                <character-class>alphabetical</character-class>
+                <length>5</length>
+            </illegal-sequence>
+            <illegal-sequence>
+                <character-class>numeric</character-class>
+                <length>5</length>
+            </illegal-sequence>
+            <illegal-sequence>
+                <character-class>qwerty</character-class>
+                <length>5</length>
+            </illegal-sequence>
+        </illegal-sequences>
+        <allow-whitespace>false</allow-whitespace>
+    </password-complexity>
     <persistence>
         <service>
             <url>http://localhost:@JEE_PORT@/cspace-services</url>


### PR DESCRIPTION
**What does this do?**
This updates the tenant binding configuration to take in additional settings for password complexity requirements.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2002

This is a requirement for better HECVAT compatibility.

**How should this be tested? Do these changes have associated tests?**
* The provided config in `tomcat-main/src/main/resources/defaults/settings.xml` need to be copied into one of the tenant `settings.xml` files (e.g. core)
* In the services application:
  * Ensure your cspace environment variables are set
  * Navigate to `services/JaxRsServiceProvider/`
  * Run the `ant deploy_services_artifacts`
* In your CSPACE_JEE_SERVER, verify the `proto` bindings contain the new `<tenant:passwordComplexity/>` section

**Dependencies for merging? Releasing to production?**
I did this on top of the JDK 21 update. Otherwise I don't believe there are any dependencies.

The way the settings are read in though is kind of a mess, and makes adding new settings more difficult than it should be. IDK the way settings are handled in general makes the entire process onerous (e.g. needing a recompile to change a value). I'll create a ticket for this to track it.

**Has the application documentation been updated for these changes?**
No. Docs will need to be added.

**Did someone actually run this code to verify it works?**
@mikejritter has generated tenant bindings locally