### PR TITLE
DRYD-2117: Procedure/Object > Ability to set Priority Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add home location group `homeLocationGroupList/homeLocationGroup`
 
+### Media
+
+* Add repeatable field `priorityImageList/priorityImage`
+
 ## 8.3.0
 
 ### Authorities

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -134,6 +134,10 @@
 			<field id="inventoryStatus" autocomplete="true" ui-type="enum" />
 		</repeat>
 
+		<repeat id="priorityImageList" services-type-anonymous="false">
+			<field id="priorityImage" />
+		</repeat>
+
 		<repeat id="titleGroupList/titleGroup">
 			<field id="title" mini="list" />
 			<field id="titleLanguage" autocomplete="true" ui-type="enum" />


### PR DESCRIPTION
**What does this do?**
It adds the repeatable field `priorityImageList/priorityImage`. The field doesn't have `autocomplete="true" ui-type="enum"` attributes because it is being prepopulated in the UI. The `services-type-anonymous="false"` is necessary so that Nuxeo creates a named join table, allowing the denorm writer to address the list by name. This is the same pattern for any repeating field that needs to be addressed by name.

**Why are we doing this? (with JIRA link)**
This is part of the https://collectionspace.atlassian.net/browse/DRYD-2117. The new repeating field stores the already related media handling records of an object sorted.

**How should this be tested? Do these changes have associated tests?**
Please follow the steps in the cspace-ui PR: https://github.com/collectionspace/cspace-ui.js/pull/360

**Dependencies for merging? Releasing to production?**
It should be released along the:
https://github.com/collectionspace/services/pull/548
https://github.com/collectionspace/cspace-ui.js/pull/360
https://github.com/collectionspace/cspace-public-browser.js/pull/57

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi tested locally