### PR TITLE
NOJIRA: Replace cspace-maven-repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,12 @@
 		<repository>
 			<id>cspace</id>
 			<name>cspace-libs-release-local</name>
-			<url>s3://cspace-maven-repo/libs-release-local</url>
+			<url>s3://cspace-program-production-cdn-cspace-maven/libs-release-local</url>
 		</repository>
 		<snapshotRepository>
 			<id>cspace</id>
 			<name>cspace-libs-snapshot-local</name>
-			<url>s3://cspace-maven-repo/libs-snapshot-local</url>
+			<url>s3://cspace-program-production-cdn-cspace-maven/libs-snapshot-local</url>
 		</snapshotRepository>
 	</distributionManagement>
 
@@ -61,7 +61,7 @@
 		<repository>
 			<id>cspace-libs-release-local</id>
 			<name>cspace-libs-release-local</name>
-			<url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/libs-release-local</url>
+			<url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/libs-release-local</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -69,7 +69,7 @@
 		<repository>
 			<id>cspace-libs-snapshot-local</id>
 			<name>cspace-libs-snapshot-local</name>
-			<url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/libs-snapshot-local</url>
+			<url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/libs-snapshot-local</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>
@@ -92,7 +92,7 @@
 		<pluginRepository>
 			<id>cspace-plugins-release-local</id>
 			<name>cspace-plugins-release-local</name>
-			<url>https://cspace-maven-repo.s3-us-west-2.amazonaws.com/plugins-release-local</url>
+			<url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/plugins-release-local</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<repository>
 			<id>cspace-libs-release-local</id>
 			<name>cspace-libs-release-local</name>
-			<url>https://cspace-program-production-cdn-cspace-maven.s3-us-west-2.amazonaws.com/libs-release-local</url>
+			<url>https://cspace-maven.collectionspace.org/libs-release-local</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>


### PR DESCRIPTION
**What does this do?**
Replaces cspace-maven-repo with cspace-program-production-cdn-cspace-maven

**Why are we doing this? (with JIRA link)**
Same as the services - the s3 bucket is changing accounts and this is the name of the new bucket.

**How should this be tested? Do these changes have associated tests?**
* The application should build successfully 

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
I'll test this again later, as mentioned in the other PR I got a 403 when trying to build