### PR TITLE
DRYD-2117: Procedure/Object > Ability to set Priority Image - Rename priority image to media priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Media
 
-* Add repeatable field `priorityImageList/priorityImage`
+* Add repeatable field `mediaPriorityList/mediaPriority`
 
 ## 8.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add home location group `homeLocationGroupList/homeLocationGroup`
 
+### Media
+
+* Add repeatable field `priorityImageList/priorityImage`
+
 ## 8.3.0
 
 ### Authorities

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -134,6 +134,10 @@
 			<field id="inventoryStatus" autocomplete="true" ui-type="enum" />
 		</repeat>
 
+		<repeat id="priorityImageList" services-type-anonymous="false">
+			<field id="priorityImage" />
+		</repeat>
+
 		<repeat id="titleGroupList/titleGroup">
 			<field id="title" mini="list" />
 			<field id="titleLanguage" autocomplete="true" ui-type="enum" />

--- a/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/base-collectionobject.xml
@@ -134,8 +134,8 @@
 			<field id="inventoryStatus" autocomplete="true" ui-type="enum" />
 		</repeat>
 
-		<repeat id="priorityImageList" services-type-anonymous="false">
-			<field id="priorityImage" />
+		<repeat id="mediaPriorityList" services-type-anonymous="false">
+			<field id="mediaPriority" />
 		</repeat>
 
 		<repeat id="titleGroupList/titleGroup">


### PR DESCRIPTION
**What does this do?**
This is a follow-up from https://github.com/collectionspace/application/pull/356. It only renames priority image to media priority.

**Why are we doing this? (with JIRA link)**
To be more consistent with the feature name.

**How should this be tested? Do these changes have associated tests?**
No need to test this actually.

**Dependencies for merging? Releasing to production?**
no dependencies

**Has the application documentation been updated for these changes?**
changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally.
