### PR TITLE
DRYD-2127: Procedure > Acquisition > Add Alternate Identifier/Note combination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * Add password complexity requirements to tenant settings.xml
 
+### Acquisition
+
+* Add alternative identifier group `alternativeIdentifierGroupList/alternativeIdentifierGroup`
+
 ### CollectionObject
 
 * Add home location group `homeLocationGroupList/homeLocationGroup`

--- a/tomcat-main/src/main/resources/defaults/base-procedure-acquisition.xml
+++ b/tomcat-main/src/main/resources/defaults/base-procedure-acquisition.xml
@@ -14,6 +14,10 @@
 
 	<section id="acquisitionInformation">
 		<field id="acquisitionReferenceNumber" mini="number,list" />
+		<repeat id="alternativeIdentifierGroupList/alternativeIdentifierGroup">
+			<field id="alternativeIdentifier" />
+			<field id="alternativeIdentifierNote" />
+		</repeat>
 		<field id="accessionDateGroup" ui-type="groupfield/structureddate">
 		</field>
 		<field id="acquisitionAuthorizer" autocomplete="true" />


### PR DESCRIPTION
**What does this do?**
It adds the Alternative Identifier/Note combination to the acquisition schema

**Why are we doing this? (with JIRA link)**
Alternate Identifier/Note combination

**How should this be tested? Do these changes have associated tests?**
Please test along the cspace-ui.js changes: https://github.com/collectionspace/cspace-ui.js/pull/364

**Dependencies for merging? Releasing to production?**
no dependencies

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally